### PR TITLE
Add Constant Data Element Type

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -200,9 +200,7 @@
         {
           "type": "function",
           "propertyPath": "source",
-          "parameters": [
-            "trigger"
-          ]
+          "parameters": ["trigger"]
         }
       ]
     },
@@ -429,10 +427,7 @@
           },
           "frequency": {
             "type": "string",
-            "enum": [
-              "firstEntry",
-              "everyEntry"
-            ]
+            "enum": ["firstEntry", "everyEntry"]
           }
         },
         "additionalProperties": false,
@@ -1123,10 +1118,7 @@
         {
           "type": "function",
           "propertyPath": "source",
-          "parameters": [
-            "event",
-            "target"
-          ]
+          "parameters": ["event", "target"]
         }
       ]
     },
@@ -1293,24 +1285,17 @@
               }
             },
             "additionalProperties": false,
-            "required": [
-              "count",
-              "unit"
-            ]
+            "required": ["count", "unit"]
           },
           {
             "properties": {
               "unit": {
                 "type": "string",
-                "enum": [
-                  "visitor"
-                ]
+                "enum": ["visitor"]
               }
             },
             "additionalProperties": false,
-            "required": [
-              "unit"
-            ]
+            "required": ["unit"]
           }
         ]
       }
@@ -1347,14 +1332,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "Windows",
-                "MacOS",
-                "Linux",
-                "Unix",
-                "iOS",
-                "Android"
-              ]
+              "enum": ["Windows", "MacOS", "Linux", "Unix", "iOS", "Android"]
             }
           }
         },
@@ -1374,21 +1352,14 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "count": {
             "type": "number"
           },
           "duration": {
             "type": "string",
-            "enum": [
-              "lifetime",
-              "session"
-            ]
+            "enum": ["lifetime", "session"]
           }
         },
         "additionalProperties": false,
@@ -1473,10 +1444,7 @@
         "properties": {
           "protocol": {
             "type": "string",
-            "enum": [
-              "http:",
-              "https:"
-            ]
+            "enum": ["http:", "https:"]
           }
         },
         "additionalProperties": false,
@@ -1495,22 +1463,14 @@
         "properties": {
           "widthOperator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "width": {
             "type": "number"
           },
           "heightOperator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "height": {
             "type": "number"
@@ -1555,11 +1515,7 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "count": {
             "type": "number"
@@ -1614,11 +1570,7 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "minutes": {
             "type": "number"
@@ -1697,18 +1649,13 @@
                 "properties": {
                   "operator": {
                     "type": "string",
-                    "enum": [
-                      "equals",
-                      "doesNotEqual"
-                    ]
+                    "enum": ["equals", "doesNotEqual"]
                   },
                   "caseInsensitive": {
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "operator"
-                ],
+                "required": ["operator"],
                 "additionalProperties": false
               },
               "rightOperand": {
@@ -1722,11 +1669,7 @@
                 ]
               }
             },
-            "required": [
-              "leftOperand",
-              "comparison",
-              "rightOperand"
-            ],
+            "required": ["leftOperand", "comparison", "rightOperand"],
             "additionalProperties": false
           },
           {
@@ -1755,9 +1698,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "operator"
-                ],
+                "required": ["operator"],
                 "additionalProperties": false
               },
               "rightOperand": {
@@ -1765,11 +1706,7 @@
                 "minLength": 1
               }
             },
-            "required": [
-              "leftOperand",
-              "comparison",
-              "rightOperand"
-            ],
+            "required": ["leftOperand", "comparison", "rightOperand"],
             "additionalProperties": false
           },
           {
@@ -1791,9 +1728,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "operator"
-                ],
+                "required": ["operator"],
                 "additionalProperties": false
               },
               "rightOperand": {
@@ -1808,11 +1743,7 @@
                 ]
               }
             },
-            "required": [
-              "leftOperand",
-              "comparison",
-              "rightOperand"
-            ],
+            "required": ["leftOperand", "comparison", "rightOperand"],
             "additionalProperties": false
           },
           {
@@ -1826,24 +1757,14 @@
                 "properties": {
                   "operator": {
                     "type": "string",
-                    "enum": [
-                      "isTrue",
-                      "isTruthy",
-                      "isFalse",
-                      "isFalsy"
-                    ]
+                    "enum": ["isTrue", "isTruthy", "isFalse", "isFalsy"]
                   }
                 },
-                "required": [
-                  "operator"
-                ],
+                "required": ["operator"],
                 "additionalProperties": false
               }
             },
-            "required": [
-              "leftOperand",
-              "comparison"
-            ],
+            "required": ["leftOperand", "comparison"],
             "additionalProperties": false
           }
         ]
@@ -1887,22 +1808,14 @@
         "properties": {
           "widthOperator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "width": {
             "type": "number"
           },
           "heightOperator": {
             "type": "string",
-            "enum": [
-              ">",
-              "=",
-              "<"
-            ]
+            "enum": [">", "=", "<"]
           },
           "height": {
             "type": "number"
@@ -1914,6 +1827,24 @@
     }
   ],
   "dataElements": [
+    {
+      "name": "constant",
+      "displayName": "Constant",
+      "libPath": "src/lib/dataElements/constant.js",
+      "viewPath": "dataElements/constant.html",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false,
+        "required": ["value"]
+      }
+    },
     {
       "name": "cookie",
       "displayName": "Cookie",
@@ -2136,9 +2067,7 @@
           {
             "properties": {
               "language": {
-                "enum": [
-                  "javascript"
-                ]
+                "enum": ["javascript"]
               },
               "global": {
                 "type": "boolean"
@@ -2149,17 +2078,12 @@
               }
             },
             "additionalProperties": false,
-            "required": [
-              "language",
-              "source"
-            ]
+            "required": ["language", "source"]
           },
           {
             "properties": {
               "language": {
-                "enum": [
-                  "html"
-                ]
+                "enum": ["html"]
               },
               "source": {
                 "type": "string",
@@ -2167,10 +2091,7 @@
               }
             },
             "additionalProperties": false,
-            "required": [
-              "language",
-              "source"
-            ]
+            "required": ["language", "source"]
           }
         ]
       },

--- a/src/lib/dataElements/__tests__/constant.test.js
+++ b/src/lib/dataElements/__tests__/constant.test.js
@@ -1,0 +1,26 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+var dataElementDelegate = require('../constant');
+
+describe('constant data element delegate', function() {
+  it('returns the value set', function() {
+    var settings = {
+      value: 'foo'
+    };
+
+    expect(dataElementDelegate(settings)).toBe('foo');
+  });
+
+});

--- a/src/lib/dataElements/constant.js
+++ b/src/lib/dataElements/constant.js
@@ -1,0 +1,25 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+/**
+ * The cookie data element.
+ * @param {Object} settings The data element settings object.
+ * @param {string} settings.value The value that the user had specified when creating this 
+ * Data Element.
+ * @returns {string}
+ */
+
+module.exports = function(settings) {
+  return settings.value;
+};

--- a/src/view/dataElements/__tests__/constant.test.jsx
+++ b/src/view/dataElements/__tests__/constant.test.jsx
@@ -1,0 +1,68 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+import { mount } from 'enzyme';
+import Textfield from '@react/react-spectrum/Textfield';
+import ConstantValue, { formConfig } from '../constant';
+import createExtensionBridge from '../../__tests__/helpers/createExtensionBridge';
+import bootstrap from '../../bootstrap';
+
+const getReactComponents = (wrapper) => {
+  wrapper.update();
+  const valueTextfield = wrapper.find(Textfield);
+
+  return {
+    valueTextfield
+  };
+};
+
+describe('constant data element view', () => {
+  let extensionBridge;
+  let instance;
+
+  beforeAll(() => {
+    extensionBridge = createExtensionBridge();
+    instance = mount(bootstrap(ConstantValue, formConfig, extensionBridge));
+  });
+
+  it('sets form values from settings', () => {
+    extensionBridge.init({
+      settings: {
+        value: 'foo'
+      }
+    });
+
+    const { valueTextfield } = getReactComponents(instance);
+
+    expect(valueTextfield.props().value).toBe('foo');
+  });
+
+  it('sets settings from form values', () => {
+    extensionBridge.init();
+
+    const { valueTextfield } = getReactComponents(instance);
+    valueTextfield.props().onChange('foo');
+
+    expect(extensionBridge.getSettings()).toEqual({
+      value: 'foo'
+    });
+  });
+
+  it('sets errors if required values are not provided', () => {
+    extensionBridge.init();
+    expect(extensionBridge.validate()).toBe(false);
+
+    const { valueTextfield } = getReactComponents(instance);
+
+    expect(valueTextfield.props().validationState).toBe('invalid');
+  });
+});

--- a/src/view/dataElements/constant.jsx
+++ b/src/view/dataElements/constant.jsx
@@ -46,7 +46,7 @@ export const formConfig = {
     };
 
     if (!values.value) {
-      errors.name = 'Please specify a value.';
+      errors.value = 'Please specify a value.';
     }
 
     return errors;

--- a/src/view/dataElements/constant.jsx
+++ b/src/view/dataElements/constant.jsx
@@ -1,0 +1,54 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+import React from 'react';
+import Textfield from '@react/react-spectrum/Textfield';
+import WrappedField from '../components/wrappedField';
+
+const ConstantValue = () => (
+  <label>
+    <span className="u-verticalAlignMiddle u-gapRight">Value for this Data Element</span>
+    <WrappedField
+      name="value"
+      component={Textfield}
+      componentClassName="u-fieldLong"
+    />
+  </label>
+);
+
+export default ConstantValue;
+
+export const formConfig = {
+  settingsToFormValues(values, settings) {
+    return {
+      ...values,
+      ...settings
+    };
+  },
+  formValuesToSettings(settings, values) {
+    return {
+      ...settings,
+      ...values
+    };
+  },
+  validate(errors, values) {
+    errors = {
+      ...errors
+    };
+
+    if (!values.value) {
+      errors.name = 'Please specify a value.';
+    }
+
+    return errors;
+  }
+};


### PR DESCRIPTION
Add a "Constant" Data Element Type

## Description

The "Constant" Data Element Type allows users to make Data Elements that have a constant value.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When using Launch, there is often a need to keep things configurable, yet constant. A constant Data Element Type is highly useful for items like a report suite ID, or a tracking server.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [ ] I have run the extension sandbox successfully.
