### PR TITLE
added support for event to be passed into custom code data element type

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1883,7 +1883,8 @@
       "transforms": [
         {
           "type": "function",
-          "propertyPath": "source"
+          "propertyPath": "source",
+          "parameters": ["event"]
         }
       ]
     },

--- a/src/lib/dataElements/__tests__/customCode.test.js
+++ b/src/lib/dataElements/__tests__/customCode.test.js
@@ -24,4 +24,17 @@ describe('custom code data element delegate', function() {
 
     expect(dataElementDelegate(settings)).toBe('foo');
   });
+
+  it('receives the event parameter if provided', function() {
+    var settings = {
+      source: function(event) {
+        return event.foo;
+      }
+    };
+    var event = {
+      'foo': 'bar'
+    };
+
+    expect(dataElementDelegate(settings, event)).toBe('bar');
+  });
 });

--- a/src/lib/dataElements/customCode.js
+++ b/src/lib/dataElements/customCode.js
@@ -16,8 +16,9 @@
  * The custom data element.
  * @param {Object} settings The data element settings object.
  * @param {string} settings.source The function that should be called which will return a value.
+ * @param {string} event The event (if any) that triggered the evaluation of the data element.
  * @returns {string}
  */
-module.exports = function(settings) {
-  return settings.source();
+module.exports = function(settings, event) {
+  return settings.source(event);
 };


### PR DESCRIPTION
## Description

By adding support for event to be passed into the custom code data element type, users can create dynamic data elements that inspect the event context and take action conditionally. 

## Related Issue

https://github.com/adobe/reactor-extension-core/issues/6

## Motivation and Context

This update will allow the creation of data elements which act upon the additional payload passed as a second parameter of _satelllite.track.  It also opens up options to create data elements that return values appropriate to the context of evaluation (typically the trigger of the rule within which the data element is being evaluated). 

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] All tests pass and I've made any necessary test changes.
- [ ] I have run the extension sandbox successfully.
