### PR TITLE
WIP - initial pass at increasing field lengths

### DIFF
--- a/src/view/conditions/cookie.jsx
+++ b/src/view/conditions/cookie.jsx
@@ -23,6 +23,7 @@ const Cookie = () => (
       <WrappedField
         name="name"
         component={Textfield}
+        componentClassName="u-fieldLong"
       />
     </label>
     <div className="u-inlineBlock u-gapRight u-gapBottom u-noWrap u-floatLeft">
@@ -31,7 +32,7 @@ const Cookie = () => (
         <WrappedField
           name="value"
           component={Textfield}
-          componentClassName="u-fieldLong"
+          componentClassName="u-fieldExtraLong"
         />
       </label>
 

--- a/src/view/conditions/hash.jsx
+++ b/src/view/conditions/hash.jsx
@@ -25,7 +25,7 @@ const renderItem = field => (
       <WrappedField
         name={`${field}.value`}
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
 

--- a/src/view/conditions/landingPage.jsx
+++ b/src/view/conditions/landingPage.jsx
@@ -22,7 +22,7 @@ export default () => (
       <WrappedField
         name="page"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <WrappedField

--- a/src/view/conditions/path.jsx
+++ b/src/view/conditions/path.jsx
@@ -24,7 +24,7 @@ const renderItem = field => (
       <WrappedField
         name={`${field}.value`}
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <WrappedField

--- a/src/view/conditions/pathAndQuerystring.jsx
+++ b/src/view/conditions/pathAndQuerystring.jsx
@@ -24,7 +24,7 @@ const renderItem = field => (
       <WrappedField
         name={`${field}.value`}
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <WrappedField

--- a/src/view/conditions/queryStringParameter.jsx
+++ b/src/view/conditions/queryStringParameter.jsx
@@ -22,6 +22,7 @@ const QueryStringParameter = () => (
       <WrappedField
         name="name"
         component={Textfield}
+        componentClassName="u-fieldLong"
       />
     </label>
     <div className="u-inlineBlock u-gapRight u-gapBottom u-noWrap u-floatLeft">
@@ -30,7 +31,7 @@ const QueryStringParameter = () => (
         <WrappedField
           name="value"
           component={Textfield}
-          componentClassName="u-fieldLong"
+          componentClassName="u-fieldExtraLong"
         />
       </label>
       <WrappedField

--- a/src/view/conditions/subdomain.jsx
+++ b/src/view/conditions/subdomain.jsx
@@ -25,7 +25,7 @@ const renderItem = field => (
       <WrappedField
         name={`${field}.value`}
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <WrappedField

--- a/src/view/conditions/trafficSource.jsx
+++ b/src/view/conditions/trafficSource.jsx
@@ -22,7 +22,7 @@ const TrafficSource = () => (
       <WrappedField
         name="source"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <WrappedField

--- a/src/view/conditions/valueComparison.jsx
+++ b/src/view/conditions/valueComparison.jsx
@@ -196,7 +196,7 @@ const RightOperandFields = ({ operator, caseInsensitive, rightOperand }) => {
             name="rightOperand"
             className="u-gapRight"
             component={Textfield}
-            componentClassName="u-fieldLong"
+            componentClassName="u-fieldExtraLong"
             supportDataElement
           />
           <WrappedField
@@ -212,7 +212,7 @@ const RightOperandFields = ({ operator, caseInsensitive, rightOperand }) => {
           <WrappedField
             name="rightOperand"
             component={Textfield}
-            componentClassName="u-fieldLong"
+            componentClassName="u-fieldExtraLong"
             supportDataElement
           />
           <NoTypeConversionReminder operator={operator} value={rightOperand} />
@@ -232,7 +232,7 @@ const ValueComparison = ({ operator, ...rest }) => (
       <WrappedField
         name="leftOperand"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
         supportDataElement
       />
     </div>

--- a/src/view/conditions/variable.jsx
+++ b/src/view/conditions/variable.jsx
@@ -23,7 +23,7 @@ const Variable = () => (
       <WrappedField
         name="name"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
         placeholder="dataLayer.products.1.price"
       />
     </label>
@@ -33,7 +33,7 @@ const Variable = () => (
         <WrappedField
           name="value"
           component={Textfield}
-          componentClassName="u-fieldLong"
+          componentClassName="u-fieldExtraLong"
         />
       </label>
       <InfoTip className="u-gapRight" placement="bottom">

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -23,7 +23,7 @@ export default () => (
       <WrappedField
         name="cspNonce"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
         supportDataElement
       />
 

--- a/src/view/dataElements/constant.jsx
+++ b/src/view/dataElements/constant.jsx
@@ -20,7 +20,7 @@ const ConstantValue = () => (
     <WrappedField
       name="value"
       component={Textfield}
-      componentClassName="u-fieldLong"
+      componentClassName="u-fieldExtraLong"
     />
   </label>
 );

--- a/src/view/dataElements/cookie.jsx
+++ b/src/view/dataElements/cookie.jsx
@@ -20,7 +20,7 @@ const Cookie = () => (
     <WrappedField
       name="name"
       component={Textfield}
-      componentClassName="u-fieldLong"
+      componentClassName="u-fieldExtraLong"
     />
   </label>
 );

--- a/src/view/dataElements/domAttribute.jsx
+++ b/src/view/dataElements/domAttribute.jsx
@@ -78,7 +78,7 @@ const DomAttribute = ({ ...props }) => {
           <WrappedField
             name="elementSelector"
             component={Textfield}
-            componentClassName="u-fieldLong"
+            componentClassName="u-fieldExtraLong"
           />
           <Link
             className="u-verticalAlignMiddle u-gapLeft"

--- a/src/view/dataElements/javascriptVariable.jsx
+++ b/src/view/dataElements/javascriptVariable.jsx
@@ -20,7 +20,7 @@ const JavaScriptVariable = () => (
     <WrappedField
       name="path"
       component={Textfield}
-      componentClassName="u-fieldLong"
+      componentClassName="u-fieldExtraLong"
       placeholder="dataLayer.products.1.price"
     />
   </label>

--- a/src/view/dataElements/localStorage.jsx
+++ b/src/view/dataElements/localStorage.jsx
@@ -20,7 +20,7 @@ const LocalStorage = () => (
     <WrappedField
       name="name"
       component={Textfield}
-      componentClassName="u-fieldLong"
+      componentClassName="u-fieldExtraLong"
     />
   </label>
 );

--- a/src/view/dataElements/queryStringParameter.jsx
+++ b/src/view/dataElements/queryStringParameter.jsx
@@ -22,6 +22,7 @@ const QueryStringParameter = () => (
       <WrappedField
         name="name"
         component={Textfield}
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <WrappedField

--- a/src/view/dataElements/sessionStorage.jsx
+++ b/src/view/dataElements/sessionStorage.jsx
@@ -20,7 +20,7 @@ const SessionStorage = () => (
     <WrappedField
       name="name"
       component={Textfield}
-      componentClassName="u-fieldLong"
+      componentClassName="u-fieldExtraLong"
     />
   </label>
 );

--- a/src/view/events/components/elementPropertiesEditor.jsx
+++ b/src/view/events/components/elementPropertiesEditor.jsx
@@ -27,6 +27,7 @@ const ElementPropertiesRenderer = ({ fields }) => (
             name={`${field}.name`}
             placeholder="Property"
             component={Textfield}
+            componentClassName="u-fieldLong"
           />
           <span className="u-verticalAlignMiddle u-gapRight u-gapLeft">&#61;</span>
           <WrappedField
@@ -34,6 +35,7 @@ const ElementPropertiesRenderer = ({ fields }) => (
             className="u-gapRight"
             placeholder="Value"
             component={Textfield}
+            componentClassName="u-fieldLong"
           />
           <WrappedField
             name={`${field}.valueIsRegex`}

--- a/src/view/events/components/elementSelector.jsx
+++ b/src/view/events/components/elementSelector.jsx
@@ -22,7 +22,7 @@ export default () => (
       <WrappedField
         name="elementSelector"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
     </label>
     <Link

--- a/src/view/events/customEvent.jsx
+++ b/src/view/events/customEvent.jsx
@@ -29,7 +29,7 @@ const CustomEvent = () => (
       <WrappedField
         name="type"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
       />
       <InfoTip placement="bottom">
         This is the name of the event that will be triggered.

--- a/src/view/events/dataElementChange.jsx
+++ b/src/view/events/dataElementChange.jsx
@@ -30,7 +30,7 @@ const DataElementChange = () => (
       <WrappedField
         name="name"
         component={Textfield}
-        componentClassName="u-fieldLong"
+        componentClassName="u-fieldExtraLong"
         supportDataElementName
       />
     </label>

--- a/src/view/events/directCall.jsx
+++ b/src/view/events/directCall.jsx
@@ -23,7 +23,7 @@ const DirectCall = () => (
     <WrappedField
       name="identifier"
       component={Textfield}
-      componentClassName="u-fieldLong"
+      componentClassName="u-fieldExtraLong"
     />
     <InfoTip placement="bottom">
       Specify the string that will be passed to _satellite.track() in your direct call,

--- a/src/view/global.styl
+++ b/src/view/global.styl
@@ -102,6 +102,10 @@ code {
   width: 370*$px !important;
 }
 
+.u-fieldExtraLong {
+ width: 740*$px !important;
+}
+
 .FieldSubset {
   padding: 0 0 8 *$px 24 *$px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
in general the field lengths in the core extension views are short, this initial pr simply makes there longer by changing some css.
Perhaps there is a better way to make the field lengths more dynamic based on screen size, but i think it will require changes at the react-spectrum layer. 

## Related Issue

## Motivation and Context

Makes the extension more usable when long js or css paths are needed.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Cosmetic
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All tests pass and I've made any necessary test changes.
- [X] I have run the extension sandbox successfully.
