### PR TITLE
Match the format emitted by Forge.

### DIFF
--- a/src/lib/actions/helpers/decorators/__tests__/decorateHtmlCode.test.js
+++ b/src/lib/actions/helpers/decorators/__tests__/decorateHtmlCode.test.js
@@ -57,7 +57,7 @@ describe('decorate html code', function() {
     var settings = {
       language: 'html',
       source:
-        '<script>_satellite._onCustomCodeSuccess(${reactorCallbackId})</script>'
+        '<script>_satellite._onCustomCodeSuccess("${reactorCallbackId}")</script>'
     };
 
     var decorateHtmlCode = decorateHtmlCodeInjector();
@@ -70,7 +70,7 @@ describe('decorate html code', function() {
     );
 
     expect(decoratedResult.code).toBe(
-      '<script>_satellite._onCustomCodeSuccess(0)</script>'
+      '<script>_satellite._onCustomCodeSuccess("0")</script>'
     );
   });
 
@@ -150,7 +150,7 @@ describe('decorate html code', function() {
       var settings = {
         language: 'html',
         source:
-          '<script>_satellite._onCustomCodeSuccess(${reactorCallbackId})</script>'
+          '<script>_satellite._onCustomCodeSuccess("${reactorCallbackId}")</script>'
       };
 
       var decorateHtmlCode = decorateHtmlCodeInjector();
@@ -167,7 +167,7 @@ describe('decorate html code', function() {
 
       flushPromiseChains().then(function() {
         expect(onPromiseResolved).not.toHaveBeenCalled();
-        window._satellite._onCustomCodeSuccess(0);
+        window._satellite._onCustomCodeSuccess('0');
       });
     }
   );
@@ -179,7 +179,7 @@ describe('decorate html code', function() {
       var settings = {
         language: 'html',
         source:
-          '<script>_satellite._onCustomCodeFailure(${reactorCallbackId})</script>'
+          '<script>_satellite._onCustomCodeFailure("${reactorCallbackId}")</script>'
       };
 
       var decorateHtmlCode = decorateHtmlCodeInjector();
@@ -195,7 +195,7 @@ describe('decorate html code', function() {
 
       flushPromiseChains().then(function() {
         expect(onPromiseRejected).not.toHaveBeenCalled();
-        window._satellite._onCustomCodeFailure(0);
+        window._satellite._onCustomCodeFailure('0');
       });
     }
   );

--- a/src/lib/actions/helpers/decorators/decorateHtmlCode.js
+++ b/src/lib/actions/helpers/decorators/decorateHtmlCode.js
@@ -70,7 +70,7 @@ module.exports = function(action, source) {
 
   if (reactorCallbackIdShouldBeReplaced(source)) {
     promise = new Promise(function(resolve, reject) {
-      htmlCodePromises[callbackId] = {
+      htmlCodePromises[String(callbackId)] = {
         resolve: resolve,
         reject: reject
       };


### PR DESCRIPTION
## Description

Forge replaces `onCustomCodeSuccess()` with `_satellite._onCustomCodeSuccess("${reactorCallbackId}")` (see the double quotes). The code and tests were expecting `_satellite._onCustomCodeSuccess(${reactorCallbackId})` (without the quotes).

The code could was functioning properly even with this inconsistency. That is because if you have `var x = {0: "some value"}`, when you call `x["0"]` you will get `"some value"` as a result (at least in Chrome.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Fixing an inconsistency.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
