### PR TITLE
Don't use document.write when action sequencing is enabled.

### DIFF
--- a/src/lib/actions/__tests__/customCode.test.js
+++ b/src/lib/actions/__tests__/customCode.test.js
@@ -70,6 +70,7 @@ describe('custom code action delegate', function() {
 
   beforeAll(function() {
     mockTurbineVariable({
+      propertySettings: {},
       getExtensionSettings: function() {
         return {};
       }
@@ -254,6 +255,7 @@ describe('custom code action delegate', function() {
             };
 
             mockTurbineVariable({
+              propertySettings: {},
               getExtensionSettings: function() {
                 return {
                   cspNonce: 'nonce'
@@ -303,6 +305,15 @@ describe('custom code action delegate', function() {
           });
 
           it('writes the code defined inside the main library', function() {
+            mockTurbineVariable({
+              propertySettings: {
+                ruleComponentSequencingEnabled: false
+              },
+              getExtensionSettings: function() {
+                return {};
+              }
+            });
+
             customCode({
               source: 'inside container',
               language: 'javascript'
@@ -325,6 +336,32 @@ describe('custom code action delegate', function() {
               done();
             });
           });
+
+          it(
+            'writes the code defined inside the main library using postscribe ' +
+              'when sequencing is enabled',
+            function(done) {
+              mockTurbineVariable({
+                propertySettings: {
+                  ruleComponentSequencingEnabled: true
+                },
+                getExtensionSettings: function() {
+                  return {};
+                }
+              });
+
+              customCode({
+                source: 'inside container',
+                language: 'javascript'
+              }).then(function() {
+                expect(postscribeSpy.calls.mostRecent().args[1]).toBe(
+                  'inside container'
+                );
+                expect(documentWriteSpy).not.toHaveBeenCalled();
+                done();
+              });
+            }
+          );
         });
 
         describe('and document.readyState is not loading', function() {

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -149,6 +149,9 @@ module.exports = function(settings, event) {
       // More info:
       // https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite
       // https://developer.mozilla.org/en-US/docs/Archive/Web/Writing_JavaScript_for_HTML
+      // Also, when rule component sequencing is enabled, there is an issue in Edge Legacy
+      // where the whole page gets erased: https://jira.corp.adobe.com/browse/DTM-13527.
+      // We decided to not use document.write at all when rule component sequencing is enabled.
       if (
         document.write &&
         turbine.propertySettings.ruleComponentSequencingEnabled === false

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -149,7 +149,10 @@ module.exports = function(settings, event) {
       // More info:
       // https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite
       // https://developer.mozilla.org/en-US/docs/Archive/Web/Writing_JavaScript_for_HTML
-      if (document.write) {
+      if (
+        document.write &&
+        turbine.propertySettings.ruleComponentSequencingEnabled === false
+      ) {
         document.write(decoratedResult.code);
       } else {
         postscribeWrite(decoratedResult.code);


### PR DESCRIPTION


## Description

Stop using document.write and action sequencing is enabled.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
