### PR TITLE
DTM-15058 Decode HTML entities from style and script tags.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",

--- a/src/lib/actions/__tests__/customCode.test.js
+++ b/src/lib/actions/__tests__/customCode.test.js
@@ -456,6 +456,79 @@ describe('custom code action delegate', function() {
     });
   });
 
+  describe('when postscribe it is used', function() {
+    var postscribeTag;
+
+    beforeEach(function() {
+      customCode = createCustomCodeDelegate({
+        document: getMockDocument({
+          write: function() {},
+          isDocumentBodyAvailable: true
+        }),
+        postscribe: function(_, src, opts) {
+          opts.beforeWriteToken(postscribeTag);
+        }
+      });
+    });
+
+    it(
+      'decodes the HTML entities from script token attrs and src attributes ' +
+        'inside beforeWriteToken callback',
+      function() {
+        postscribeTag = {
+          tagName: 'script',
+          attrs: { src: 'https://www.google.com/?id=DC&amp;l=gtmDataLayer' },
+          src: 'https://www.google.com/?id=DC&amp;l=gtmDataLayer'
+        };
+
+        customCode({
+          source:
+            '<script src="https://www.google.com/?id=DC&amp;l=gtmDataLayer"></script>',
+          language: 'html'
+        });
+
+        expect(postscribeTag.attrs.src).toBe(
+          'https://www.google.com/?id=DC&l=gtmDataLayer'
+        );
+        expect(postscribeTag.src).toBe(
+          'https://www.google.com/?id=DC&l=gtmDataLayer'
+        );
+      }
+    );
+
+    it(
+      'decodes the HTML entities from style token attrs attribute ' +
+        'inside beforeWriteToken callback',
+      function() {
+        postscribeTag = {
+          tagName: 'style',
+          attrs: { 'data-id': 'a &amp; b' }
+        };
+
+        customCode({
+          source: '<style data-id="a &amp; b"></style>',
+          language: 'html'
+        });
+
+        expect(postscribeTag.attrs['data-id']).toBe('a & b');
+      }
+    );
+
+    it('lets the browser decode the HTML entities from other token attrs attributes', function() {
+      postscribeTag = {
+        tagName: 'div',
+        attrs: { 'data-id': 'a &amp; b' }
+      };
+
+      customCode({
+        source: '<div data-id="a &amp; b"></div>',
+        language: 'html'
+      });
+
+      expect(postscribeTag.attrs['data-id']).toBe('a &amp; b');
+    });
+  });
+
   describe('returns the promise received from the decorateCode module', function() {
     beforeEach(function() {
       customCode = createCustomCodeDelegate({

--- a/src/lib/actions/__tests__/customCode.test.js
+++ b/src/lib/actions/__tests__/customCode.test.js
@@ -456,7 +456,7 @@ describe('custom code action delegate', function() {
     });
   });
 
-  describe('when postscribe it is used', function() {
+  describe('when postscribe is used', function() {
     var postscribeTag;
 
     beforeEach(function() {

--- a/src/lib/actions/__tests__/customCode.test.js
+++ b/src/lib/actions/__tests__/customCode.test.js
@@ -514,6 +514,24 @@ describe('custom code action delegate', function() {
       }
     );
 
+    it(
+      'decodes the HTML entities from the token attrs attribute ' +
+        'inside beforeWriteToken callback even when the tag name is uppercase',
+      function() {
+        postscribeTag = {
+          tagName: 'STYLE',
+          attrs: { 'data-id': 'a &amp; b' }
+        };
+
+        customCode({
+          source: '<STYLE data-id="a &amp; b"></STYLE>',
+          language: 'html'
+        });
+
+        expect(postscribeTag.attrs['data-id']).toBe('a & b');
+      }
+    );
+
     it('lets the browser decode the HTML entities from other token attrs attributes', function() {
       postscribeTag = {
         tagName: 'div',

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -16,16 +16,32 @@ var document = require('@adobe/reactor-document');
 var decorateCode = require('./helpers/decorateCode');
 var loadCodeSequentially = require('./helpers/loadCodeSequentially');
 var postscribe = require('../../../node_modules/postscribe/dist/postscribe');
+var unescapeHTMLEntities = require('./helpers/unescapeHtmlCode');
+
 var extensionSettings = turbine.getExtensionSettings();
 
 var postscribeWrite = (function() {
   var write = function(source) {
     postscribe(document.body, source, {
-      beforeWriteToken: function(tag) {
-        if (extensionSettings.cspNonce && tag.tagName === 'script') {
-          tag.attrs.nonce = extensionSettings.cspNonce;
+      beforeWriteToken: function(token) {
+        if (extensionSettings.cspNonce && token.tagName === 'script') {
+          token.attrs.nonce = extensionSettings.cspNonce;
         }
-        return tag;
+
+        // There is an issue in Postscribe where script and style attributes
+        // are not escaped. That causes problems when loading scripts from external
+        // sources. See https://jira.corp.adobe.com/browse/DTM-15058.
+        if (token.tagName === 'script' || token.tagName === 'style') {
+          Object.keys(token.attrs || []).forEach(function(key) {
+            token.attrs[key] = unescapeHTMLEntities(token.attrs[key]);
+          });
+
+          if (token.src) {
+            token.src = unescapeHTMLEntities(token.src);
+          }
+        }
+
+        return token;
       },
       error: function(error) {
         turbine.logger.error(error.msg);

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -31,7 +31,7 @@ var postscribeWrite = (function() {
         }
 
         // There is an issue in Postscribe where script and style attributes
-        // are not escaped. That causes problems when loading scripts from external
+        // are not unescaped. That causes problems when loading scripts from external
         // sources. See https://jira.corp.adobe.com/browse/DTM-15058.
         if (tagName === 'script' || tagName === 'style') {
           Object.keys(token.attrs || {}).forEach(function(key) {

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -24,14 +24,16 @@ var postscribeWrite = (function() {
   var write = function(source) {
     postscribe(document.body, source, {
       beforeWriteToken: function(token) {
-        if (extensionSettings.cspNonce && token.tagName === 'script') {
+        var tagName = token.tagName.toLowerCase();
+
+        if (extensionSettings.cspNonce && tagName === 'script') {
           token.attrs.nonce = extensionSettings.cspNonce;
         }
 
         // There is an issue in Postscribe where script and style attributes
         // are not escaped. That causes problems when loading scripts from external
         // sources. See https://jira.corp.adobe.com/browse/DTM-15058.
-        if (token.tagName === 'script' || token.tagName === 'style') {
+        if (tagName === 'script' || tagName === 'style') {
           Object.keys(token.attrs || []).forEach(function(key) {
             token.attrs[key] = unescapeHTMLEntities(token.attrs[key]);
           });

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -34,7 +34,7 @@ var postscribeWrite = (function() {
         // are not escaped. That causes problems when loading scripts from external
         // sources. See https://jira.corp.adobe.com/browse/DTM-15058.
         if (tagName === 'script' || tagName === 'style') {
-          Object.keys(token.attrs || []).forEach(function(key) {
+          Object.keys(token.attrs || {}).forEach(function(key) {
             token.attrs[key] = unescapeHTMLEntities(token.attrs[key]);
           });
 

--- a/src/lib/actions/helpers/__tests__/unescapeHtmlCode.test.js
+++ b/src/lib/actions/helpers/__tests__/unescapeHtmlCode.test.js
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+'use strict';
+
+var unescapeHtmlCode = require('../unescapeHtmlCode');
+
+describe('unescape html code', function() {
+  it('decodes html entities', function() {
+    expect(
+      unescapeHtmlCode('https://www.google.com/?id=DC&amp;l=gtmData&gt;Layer')
+    ).toBe('https://www.google.com/?id=DC&l=gtmData>Layer');
+  });
+});

--- a/src/lib/actions/helpers/unescapeHtmlCode.js
+++ b/src/lib/actions/helpers/unescapeHtmlCode.js
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+'use strict';
+
+var document = require('@adobe/reactor-document');
+var el = document.createElement('div');
+
+module.exports = function(html) {
+  el.innerHTML = html;
+
+  // IE and Firefox differ.
+  return el.textContent || el.innerText || html;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Postscribe doesn't handle HTML entity decoding for `style` and `script` tags. Taking care of that inside beforeWriteToken callback.

## Description

https://jira.corp.adobe.com/browse/DTM-15058
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
