### PR TITLE
DTM-15195 Handle the case when no code exists inside the action.

### DIFF
--- a/src/lib/actions/__tests__/customCode.test.js
+++ b/src/lib/actions/__tests__/customCode.test.js
@@ -28,9 +28,11 @@ var createCustomCodeDelegate = function(mocks) {
         promise: Promise.resolve('promise result from inside the decorators')
       };
     },
-    './helpers/loadCodeSequentially': function() {
-      return Promise.resolve('inside external file');
-    }
+    './helpers/loadCodeSequentially':
+      mocks.loadCodeSequentially ||
+      function() {
+        return Promise.resolve('inside external file');
+      }
   });
 };
 
@@ -573,6 +575,28 @@ describe('custom code action delegate', function() {
         language: 'javascript'
       }).then(function(result) {
         expect(result).toBe('promise result from inside the decorators');
+
+        done();
+      });
+    });
+  });
+
+  describe('returns a resolved promise', function() {
+    it('for empty code defined inside an external file', function(done) {
+      customCode = createCustomCodeDelegate({
+        postscribe: postscribeSpy,
+        document: getMockDocument({}),
+        loadCodeSequentially: function() {
+          return Promise.resolve('');
+        }
+      });
+
+      customCode({
+        isExternal: true,
+        source: 'http://someurl.com/source.js',
+        language: 'javascript'
+      }).then(function(result) {
+        expect(result).toBeUndefined();
 
         done();
       });

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -13,6 +13,7 @@
 'use strict';
 
 var document = require('@adobe/reactor-document');
+var Promise = require('@adobe/reactor-promise');
 var decorateCode = require('./helpers/decorateCode');
 var loadCodeSequentially = require('./helpers/loadCodeSequentially');
 var postscribe = require('../../../node_modules/postscribe/dist/postscribe');
@@ -133,9 +134,10 @@ module.exports = function(settings, event) {
       if (source) {
         decoratedResult = decorateCode(action, source);
         postscribeWrite(decoratedResult.code);
+        return decoratedResult.promise;
       }
 
-      return decoratedResult.promise;
+      return Promise.resolve();
     });
   } else {
     decoratedResult = decorateCode(action, source);


### PR DESCRIPTION
When an external action didn't contain code an unhandled exception was thrown.

## Description

The error happens when an external custom code action has no content. This can happen in 2 cases:

When somebody adds an empty action to the build.
When somebody comments all the code from an action. The minifier will remove the comments, thus the emitted action will be empty.

## Related Issue

https://jira.corp.adobe.com/browse/DTM-15195


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
