### PR TITLE
DTM-15203 Handle tokens that don't have tagName property.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",

--- a/src/lib/actions/__tests__/customCode.test.js
+++ b/src/lib/actions/__tests__/customCode.test.js
@@ -547,6 +547,22 @@ describe('custom code action delegate', function() {
 
       expect(postscribeTag.attrs['data-id']).toBe('a &amp; b');
     });
+
+    it('beforeWriteToken does not throw error for comments tokens', function() {
+      postscribeTag = {
+        content: ' comment -->',
+        length: 16,
+        text: '<!-- comment -->',
+        type: 'comment'
+      };
+
+      expect(function() {
+        customCode({
+          source: '<!-- comment -->',
+          language: 'html'
+        });
+      }).not.toThrow();
+    });
   });
 
   describe('returns the promise received from the decorateCode module', function() {

--- a/src/lib/actions/customCode.js
+++ b/src/lib/actions/customCode.js
@@ -25,7 +25,7 @@ var postscribeWrite = (function() {
   var write = function(source) {
     postscribe(document.body, source, {
       beforeWriteToken: function(token) {
-        var tagName = token.tagName.toLowerCase();
+        var tagName = token.tagName && token.tagName.toLowerCase();
 
         if (extensionSettings.cspNonce && tagName === 'script') {
           token.attrs.nonce = extensionSettings.cspNonce;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Custom code action throws `Uncaught TypeError: Cannot read property 'toLowerCase' of undefined` for HTML code that contains comments.

## Related Issue

https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=1676&selectedIssue=DTM-15203
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
