### PR TITLE
Fix JS error that appears when the extension views are loaded in Lens.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = env => {
               chunks: ['common', chunkName],
               react_dev_hook:
                 env === 'sandbox'
-                  ? '<script> __REACT_DEVTOOLS_GLOBAL_HOOK__ = parent.__REACT_DEVTOOLS_GLOBAL_HOOK__ </script>'
+                  ? '<script> try { __REACT_DEVTOOLS_GLOBAL_HOOK__ = parent.__REACT_DEVTOOLS_GLOBAL_HOOK__ } catch(error) {}</script>'
                   : ''
             })
           );
@@ -134,7 +134,7 @@ module.exports = env => {
                 importLoaders: 1
               }
             },
-            require.resolve('stylus-loader'),
+            require.resolve('stylus-loader')
           ]
         },
         {


### PR DESCRIPTION
Due to the way Lens loads extension views in iframes, a JS error is thrown in the console.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
