### PR TITLE
Fixes bug where you couldn't remove CSP nonce value and save

### DIFF
--- a/src/view/configuration/__tests__/configuration.test.jsx
+++ b/src/view/configuration/__tests__/configuration.test.jsx
@@ -90,4 +90,20 @@ describe('extension configuration view', () => {
 
     expect(cspNonceTextfield.props().validationState).toBe('invalid');
   });
+
+  it('removes cspNonce from the settings object if the value is falsy', () => {
+    extensionBridge.init({
+      settings: {
+        cspNonce: '%foo%'
+      }
+    });
+
+    const { cspNonceTextfield } = getReactComponents(instance);
+
+    cspNonceTextfield.props().onChange('');
+
+    expect(extensionBridge.getSettings()).toEqual({});
+
+    expect(extensionBridge.validate()).toBe(true);
+  });
 });

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -47,6 +47,10 @@ export const formConfig = {
     };
   },
   formValuesToSettings(settings, values) {
+    if (!values.cspNonce) {
+      delete values.cspNonce;
+    }
+
     return {
       ...settings,
       ...values


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Users were unable to remove their previously saved CSP nonce value, because an empty string wasn't matching the save schema. Fixed this by removing the CSP nonce property from the settings block if the value is falsy.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://jira.corp.adobe.com/browse/DTM-15636

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Users can now remove their csp nonce values and save their changes in the extension configuration view.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
