### PR TITLE
BUG_FIX: Trigger Specific Synthetic Event

### DIFF
--- a/src/lib/events/directCall.js
+++ b/src/lib/events/directCall.js
@@ -30,12 +30,12 @@ window._satellite.track = function(identifier, detail) {
   identifier = identifier.trim();
   var triggers = triggersByIdentifier[identifier];
   if (triggers) {
-    var syntheticEvent = {
-      identifier: identifier,
-      detail: detail
-    };
-
+    
     triggers.forEach(function(trigger) {
+      var syntheticEvent = {
+        identifier: identifier,
+        detail: detail
+      };
       trigger(syntheticEvent);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bug- Multiple rules triggering on the same direct call event (i.e. having the same direct call identifier), reference a common syntheticEvent object, causing incorrect information (especially syntheticEventMeta info) being accessed by the corresponding rule components which run asynchronously.

## Related Issue
https://github.com/adobe/reactor-extension-core/issues/35

## Motivation and Context
It solves the problem with asynchronous rule components being executed by rules which trigger on direct call events

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I have run the extension sandbox successfully.
