### PR TITLE
DTM-16063: show a deprecation message when Link Delay is on.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 14.x
       - run: yarn install --frozen-lockfile
-      - uses: saucelabs/sauce-connect-action@master
+      - uses: saucelabs/sauce-connect-action@v1
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",

--- a/src/view/components/helpText.jsx
+++ b/src/view/components/helpText.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Flex, Text, View } from '@adobe/react-spectrum';
+import Alert from '@spectrum-icons/workflow/Alert';
+import './helpText.styl';
+
+const colorToClassName = (color) => {
+  const className = `spectrum-semantic-${color}-color-text-small`;
+  switch (color) {
+    case 'negative':
+      return className;
+    default:
+      return undefined;
+  }
+};
+
+export default ({ color = 'notice', children, ...containerProps }) => (
+  <Flex gap="size-200" {...containerProps}>
+    <View
+      // for when spectrum views support color slot context...
+      color={color}
+    >
+      <Flex gap="size-100">
+        <Alert
+          aria-label="Alert"
+          size="S"
+          //remove when color slot context is available on View
+          color={color}
+        />
+        <Text
+          //remove when color slot context is available on View
+          UNSAFE_className={colorToClassName(color)}
+        >
+          {children}
+        </Text>
+      </Flex>
+    </View>
+  </Flex>
+);

--- a/src/view/components/helpText.styl
+++ b/src/view/components/helpText.styl
@@ -1,0 +1,3 @@
+.spectrum-semantic-negative-color-text-small {
+  color: var(--spectrum-semantic-negative-color-text-small);
+}

--- a/src/view/components/warningContainer.jsx
+++ b/src/view/components/warningContainer.jsx
@@ -10,16 +10,13 @@ governing permissions and limitations under the License.
 */
 
 import React from 'react';
-import { Flex, View, Well, Text } from '@adobe/react-spectrum';
-import Alert from '@spectrum-icons/workflow/Alert';
+import { Flex, Well } from '@adobe/react-spectrum';
+import HelpText from './helpText';
 
-export default ({ children, ...rest }) => (
-  <Well {...rest}>
-    <Flex gap="size-100">
-      <View>
-        <Alert aria-label="Alert" color="notice" />
-      </View>
-      <Text marginTop="size-50">{children}</Text>
+export default ({ color = 'notice', children, ...containerPositioning }) => (
+  <Well {...containerPositioning}>
+    <Flex gap="size-200">
+      <HelpText color={color}>{children}</HelpText>
     </Flex>
   </Well>
 );

--- a/src/view/conditions/__tests__/deviceType.test.jsx
+++ b/src/view/conditions/__tests__/deviceType.test.jsx
@@ -38,6 +38,14 @@ describe('device type condition view', () => {
     delete window.extensionBridge;
   });
 
+  it('shows a deprecation message', () => {
+    expect(
+      screen.getByText(
+        /This condition type is no longer supported. Please avoid its use./i
+      )
+    ).toBeTruthy();
+  });
+
   it('sets form values from settings', () => {
     extensionBridge.init({
       settings: {

--- a/src/view/conditions/sampling.jsx
+++ b/src/view/conditions/sampling.jsx
@@ -17,7 +17,7 @@ import { formValueSelector, getFormInitialValues } from 'redux-form';
 import { connect } from 'react-redux';
 import InfoTip from '../components/infoTip';
 import WrappedField from '../components/wrappedField';
-import WarningContainer from '../components/warningContainer';
+import HelpText from '../components/helpText';
 import NoWrapText from '../components/noWrapText';
 
 const Sampling = ({ showCohortResetInfo }) => (
@@ -27,6 +27,12 @@ const Sampling = ({ showCohortResetInfo }) => (
       <WrappedField label="Rate" name="rate" component={TextField} isRequired />
       <Text marginBottom="size-75">percent of the time.</Text>
     </Flex>
+    {Boolean(showCohortResetInfo) && (
+      <HelpText marginBottom="size-200">
+        Changing the sampling value will reset the cohort the next time the rule
+        is published.
+      </HelpText>
+    )}
 
     <Flex alignItems="center" marginTop="size-100">
       <WrappedField name="persistCohort" component={Checkbox}>
@@ -39,13 +45,6 @@ const Sampling = ({ showCohortResetInfo }) => (
         user and vice versa.
       </InfoTip>
     </Flex>
-
-    {showCohortResetInfo ? (
-      <WarningContainer>
-        Changing the sampling value will reset the cohort the next time the rule
-        is published.
-      </WarningContainer>
-    ) : null}
   </>
 );
 

--- a/src/view/conditions/valueComparison.jsx
+++ b/src/view/conditions/valueComparison.jsx
@@ -28,7 +28,7 @@ import { TextField, Checkbox, Picker, Item, Flex } from '@adobe/react-spectrum';
 import { formValueSelector } from 'redux-form';
 import RegexTestButton from '../components/regexTestButton';
 import WrappedField from '../components/wrappedField';
-import WarningContainer from '../components/warningContainer';
+import HelpText from '../components/helpText';
 import NoWrapText from '../components/noWrapText';
 import { isDataElementToken, isNumberLike } from '../utils/validators';
 
@@ -180,11 +180,11 @@ const NoTypeConversionReminder = ({ operator, value }) => {
   return (operator === operators.EQUALS ||
     operator === operators.DOES_NOT_EQUAL) &&
     sketchyStrings.indexOf(value.toLowerCase()) !== -1 ? (
-    <WarningContainer>
+    <HelpText>
       Be aware that the value &quot;
       {value}
       &quot; will be compared as a string.
-    </WarningContainer>
+    </HelpText>
   ) : null;
 };
 

--- a/src/view/events/__tests__/click.test.jsx
+++ b/src/view/events/__tests__/click.test.jsx
@@ -25,6 +25,16 @@ const pageElements = {
     getTextBox: () => screen.getByRole('textbox', { name: /link delay/i }),
     getDataElementModalTrigger: () => {
       return screen.getByRole('button', { name: /select a data element/i });
+    },
+    getDeprecationText: () => {
+      return screen.getByText(
+        /ink Delay is provided for backward compatibility/i
+      );
+    },
+    queryForDeprecationText: () => {
+      return screen.queryByText(
+        /link Delay is provided for backward compatibility/i
+      );
     }
   }
 };
@@ -212,5 +222,30 @@ describe('click event view', () => {
     expect(
       pageElements.linkDelay.getTextBox().hasAttribute('aria-invalid')
     ).toBeFalse();
+  });
+
+  describe('deprecation warning', () => {
+    it('does not show the message by default', () => {
+      expect(pageElements.linkDelay.queryForDeprecationText()).toBeNull();
+    });
+
+    it('shows the deprecation message when the user clicks the checkbox', () => {
+      fireEvent.click(pageElements.linkDelay.getCheckBox());
+      expect(pageElements.linkDelay.getDeprecationText()).toBeTruthy();
+    });
+
+    it(
+      'shows the deprecation message when the user already had linkDelay enabled ' +
+        'in settings',
+      () => {
+        extensionBridge.init({
+          settings: {
+            anchorDelay: 101
+          }
+        });
+
+        expect(pageElements.linkDelay.getDeprecationText()).toBeTruthy();
+      }
+    );
   });
 });

--- a/src/view/events/click.jsx
+++ b/src/view/events/click.jsx
@@ -23,6 +23,7 @@ import AdvancedEventOptions, {
 } from './components/advancedEventOptions';
 import mergeFormConfigs from '../utils/mergeFormConfigs';
 import { isDataElementToken, isNumberLikeInRange } from '../utils/validators';
+import HelpText from '../components/helpText';
 
 const Click = ({ delayLinkActivation }) => (
   <>
@@ -33,6 +34,10 @@ const Click = ({ delayLinkActivation }) => (
 
     {delayLinkActivation ? (
       <View marginBottom="size-100">
+        <HelpText marginBottom="size-200">
+          Link Delay is provided for backward compatibility with DTM
+          implementations, but is no longer supported or recommended for use.
+        </HelpText>
         <WrappedField
           name="anchorDelay"
           label="Link delay"

--- a/src/view/events/components/specificElements.jsx
+++ b/src/view/events/components/specificElements.jsx
@@ -21,7 +21,7 @@ import ElementSelector, {
 import ElementPropertiesEditor, {
   formConfig as elementPropertiesEditorFormConfig
 } from './elementPropertiesEditor';
-import WarningContainer from '../../components/warningContainer';
+import HelpText from '../../components/helpText';
 import mergeFormConfigs from '../../utils/mergeFormConfigs';
 
 const SpecificElements = ({ ...props }) => {
@@ -37,11 +37,11 @@ const SpecificElements = ({ ...props }) => {
         </WrappedField>
         {showElementPropertiesFilter ? (
           <>
-            <WarningContainer marginBottom="size-200">
+            <HelpText marginBottom="size-200">
               Using this option to target elements will add logic to the
               JavaScript library that will adversely affect performance. Adobe
               recommends using the CSS selector option above.
-            </WarningContainer>
+            </HelpText>
 
             <ElementPropertiesEditor />
           </>


### PR DESCRIPTION
Add a test for the deprecation message for deviceType.

As a part of the Link Delay epic, we've decided to sunset it as a recommended way to delay navigation. This adds a new warning message when the checkbox is turned on.

## Description

1. Show a deprecation message on link delay when it's turned on.
2. Introduces a Spectrum design pattern of "help text" below fields. https://spectrum.corp.adobe.com/page/help-text/#Icon
3. Converts other fields to use the new help text look, but maintains the old warning style for page level warnings
4. Tests when deprecation message shows up.

## Related Issue

https://jira.corp.adobe.com/browse/DTM-16063

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Backwards-compatible messaging to stop using a previously supported feature 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
