### PR TITLE
DTM-13847: Fix the new Data Element supported fields bug(s)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",

--- a/src/view/__tests__/helpers/react-testing-library.jsx
+++ b/src/view/__tests__/helpers/react-testing-library.jsx
@@ -12,6 +12,7 @@
 
 /*eslint import/no-extraneous-dependencies: 0*/
 import {
+  fireEvent,
   screen,
   waitFor,
   waitForElementToBeRemoved
@@ -29,6 +30,14 @@ export const DEBUG_UTILITIES = {
       },
       { timeout: 5000 }
     );
+  }
+};
+
+// todo: need to debug why we can't triple click and clear fields
+//  then use `userEvent.clear` and delete this function.
+export const simulate = {
+  clear: (element) => {
+    fireEvent.change(element, { target: { value: '' } });
   }
 };
 

--- a/src/view/actions/__tests__/directCall.test.jsx
+++ b/src/view/actions/__tests__/directCall.test.jsx
@@ -11,6 +11,7 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import DirectCallIdentifier, { formConfig } from '../directCall';
 import bootstrap from '../../bootstrap';
@@ -46,9 +47,7 @@ describe('direct call action view', () => {
   });
 
   it('sets settings from form values', () => {
-    fireEvent.change(pageElements.getIdentifierTextBox(), {
-      target: { value: 'foo' }
-    });
+    userEvent.type(pageElements.getIdentifierTextBox(), 'foo');
 
     expect(extensionBridge.getSettings()).toEqual({
       identifier: 'foo'

--- a/src/view/components/__tests__/wrappedField.test.jsx
+++ b/src/view/components/__tests__/wrappedField.test.jsx
@@ -110,7 +110,7 @@ describe('wrapped field', () => {
     });
 
     const inputComponent = screen.getByRole('textbox', { name: /product/i });
-    fireEvent.change(inputComponent, { target: { value: 'foo' } });
+    userEvent.type(inputComponent, 'foo');
 
     expect(extensionBridge.getSettings()).toEqual({
       product: 'foo'

--- a/src/view/conditions/__tests__/dateRange.test.jsx
+++ b/src/view/conditions/__tests__/dateRange.test.jsx
@@ -12,18 +12,13 @@
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { clickSpectrumOption } from '@test-helpers/react-testing-library';
+import {
+  simulate,
+  clickSpectrumOption
+} from '@test-helpers/react-testing-library';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import DateRange, { formConfig } from '../dateRange';
 import bootstrap from '../../bootstrap';
-
-// todo: need to debug why we can't triple click and clear fields
-//  then use `userEvent.clear` and delete this function.
-const simulate = {
-  clear: (element) => {
-    fireEvent.change(element, { target: { value: '' } });
-  }
-};
 
 // react-testing-library element selectors
 const pageElements = {

--- a/src/view/conditions/__tests__/maxFrequency.test.jsx
+++ b/src/view/conditions/__tests__/maxFrequency.test.jsx
@@ -11,7 +11,9 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
+  simulate,
   clickSpectrumOption,
   safelyWaitForElementToBeRemoved
 } from '@test-helpers/react-testing-library';
@@ -78,9 +80,8 @@ describe('max frequency condition view', () => {
       screen.queryByRole('option', { name: /session/i })
     );
 
-    fireEvent.change(pageElements.getCountTextBox(), {
-      target: { value: '3' }
-    });
+    simulate.clear(pageElements.getCountTextBox());
+    userEvent.type(pageElements.getCountTextBox(), '3');
 
     expect(extensionBridge.getSettings()).toEqual({
       count: 3,
@@ -97,9 +98,7 @@ describe('max frequency condition view', () => {
     });
 
     fireEvent.focus(pageElements.getCountTextBox());
-    fireEvent.change(pageElements.getCountTextBox(), {
-      target: { value: '-1' }
-    });
+    userEvent.type(pageElements.getCountTextBox(), '-1');
     fireEvent.blur(pageElements.getCountTextBox());
 
     expect(
@@ -108,9 +107,7 @@ describe('max frequency condition view', () => {
     expect(extensionBridge.validate()).toBe(false);
 
     fireEvent.focus(pageElements.getCountTextBox());
-    fireEvent.change(pageElements.getCountTextBox(), {
-      target: { value: '' }
-    });
+    simulate.clear(pageElements.getCountTextBox());
     fireEvent.blur(pageElements.getCountTextBox());
 
     expect(

--- a/src/view/conditions/__tests__/pageViews.test.jsx
+++ b/src/view/conditions/__tests__/pageViews.test.jsx
@@ -11,6 +11,7 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   clickSpectrumOption,
   safelyWaitForElementToBeRemoved
@@ -85,10 +86,7 @@ describe('page views condition view', () => {
     await safelyWaitForElementToBeRemoved(() =>
       screen.queryByRole('option', { name: /equal to/i })
     );
-
-    fireEvent.change(pageElements.getCountTextBox(), {
-      target: { value: '100' }
-    });
+    userEvent.type(pageElements.getCountTextBox(), '100');
 
     fireEvent.click(pageElements.duration.radioGroup.getCurrentSession());
 
@@ -110,9 +108,7 @@ describe('page views condition view', () => {
   });
 
   it('sets error if count value is not a number', () => {
-    fireEvent.change(pageElements.getCountTextBox(), {
-      target: { value: '12.abc' }
-    });
+    userEvent.type(pageElements.getCountTextBox(), '12.abc');
     fireEvent.blur(pageElements.getCountTextBox());
 
     expect(

--- a/src/view/dataElements/__tests__/randomNumber.test.jsx
+++ b/src/view/dataElements/__tests__/randomNumber.test.jsx
@@ -10,8 +10,9 @@
  * governing permissions and limitations under the License.
  ****************************************************************************************/
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { simulate } from '@test-helpers/react-testing-library';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import RandomNumber, { formConfig } from '../randomNumber';
 import bootstrap from '../../bootstrap';
@@ -20,14 +21,6 @@ import bootstrap from '../../bootstrap';
 const pageElements = {
   getMinTextBox: () => screen.getByRole('textbox', { name: /min/i }),
   getMaxTextBox: () => screen.getByRole('textbox', { name: /max/i })
-};
-
-// todo: need to debug why we can't triple click and clear fields
-//  then use `userEvent.clear` and delete this function.
-const simulate = {
-  clear: (element) => {
-    fireEvent.change(element, { target: { value: '' } });
-  }
 };
 
 describe('random number data element view', () => {

--- a/src/view/events/__tests__/click.test.jsx
+++ b/src/view/events/__tests__/click.test.jsx
@@ -11,7 +11,11 @@
  ****************************************************************************************/
 
 import { render, fireEvent, screen } from '@testing-library/react';
-import { sharedTestingElements } from '@test-helpers/react-testing-library';
+import userEvent from '@testing-library/user-event';
+import {
+  simulate,
+  sharedTestingElements
+} from '@test-helpers/react-testing-library';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import Click, { formConfig } from '../click';
 import bootstrap from '../../bootstrap';
@@ -103,11 +107,9 @@ describe('click event view', () => {
     fireEvent.focus(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox()
     );
-    fireEvent.change(
+    userEvent.type(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox(),
-      {
-        target: { value: '.foo' }
-      }
+      '.foo'
     );
     fireEvent.blur(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox()
@@ -120,9 +122,8 @@ describe('click event view', () => {
 
     fireEvent.click(pageElements.linkDelay.getCheckBox());
     fireEvent.focus(pageElements.linkDelay.getTextBox());
-    fireEvent.change(pageElements.linkDelay.getTextBox(), {
-      target: { value: '101' }
-    });
+    simulate.clear(pageElements.linkDelay.getTextBox());
+    userEvent.type(pageElements.linkDelay.getTextBox(), '101');
     fireEvent.blur(pageElements.linkDelay.getTextBox());
     expect(
       pageElements.linkDelay.getTextBox().hasAttribute('aria-invalid')
@@ -160,9 +161,7 @@ describe('click event view', () => {
 
     fireEvent.click(pageElements.linkDelay.getCheckBox());
     fireEvent.focus(pageElements.linkDelay.getTextBox());
-    fireEvent.change(pageElements.linkDelay.getTextBox(), {
-      target: { value: '' }
-    });
+    simulate.clear(pageElements.linkDelay.getTextBox());
     fireEvent.blur(pageElements.linkDelay.getTextBox());
 
     expect(
@@ -180,6 +179,8 @@ describe('click event view', () => {
     expect(
       pageElements.linkDelay.getTextBox().getAttribute('aria-invalid')
     ).toBeFalsy();
+
+    expect(extensionBridge.getSettings().anchorDelay).toBe(100);
   });
 
   it('sets validation error when the number < 1', () => {
@@ -190,9 +191,8 @@ describe('click event view', () => {
     ).toBeFalse();
 
     fireEvent.focus(pageElements.linkDelay.getTextBox());
-    fireEvent.change(pageElements.linkDelay.getTextBox(), {
-      target: { value: '0' }
-    });
+    simulate.clear(pageElements.linkDelay.getTextBox());
+    userEvent.type(pageElements.linkDelay.getTextBox(), '0');
     fireEvent.blur(pageElements.linkDelay.getTextBox());
 
     expect(
@@ -214,14 +214,15 @@ describe('click event view', () => {
     fireEvent.click(pageElements.linkDelay.getCheckBox());
 
     fireEvent.focus(pageElements.linkDelay.getTextBox());
-    fireEvent.change(pageElements.linkDelay.getTextBox(), {
-      target: { value: '%Data Element 1%' }
-    });
+    simulate.clear(pageElements.linkDelay.getTextBox());
+    userEvent.type(pageElements.linkDelay.getTextBox(), '%Data Element 1%');
     fireEvent.blur(pageElements.linkDelay.getTextBox());
 
     expect(
       pageElements.linkDelay.getTextBox().hasAttribute('aria-invalid')
     ).toBeFalse();
+
+    expect(extensionBridge.getSettings().anchorDelay).toBe('%Data Element 1%');
   });
 
   describe('deprecation warning', () => {

--- a/src/view/events/__tests__/entersViewport.test.jsx
+++ b/src/view/events/__tests__/entersViewport.test.jsx
@@ -11,6 +11,7 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { sharedTestingElements } from '@test-helpers/react-testing-library';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import EntersViewport, { formConfig } from '../entersViewport';
@@ -83,11 +84,9 @@ describe('enters viewport event view', () => {
     fireEvent.focus(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox()
     );
-    fireEvent.change(
+    userEvent.type(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox(),
-      {
-        target: { value: '.foo' }
-      }
+      '.foo'
     );
     fireEvent.blur(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox()
@@ -100,9 +99,7 @@ describe('enters viewport event view', () => {
 
     fireEvent.click(pageElements.delayWhenEnters.radioGroup.getAfterDelay());
     fireEvent.focus(pageElements.delayWhenEnters.getDelayTextBox());
-    fireEvent.change(pageElements.delayWhenEnters.getDelayTextBox(), {
-      target: { value: '100' }
-    });
+    userEvent.type(pageElements.delayWhenEnters.getDelayTextBox(), '100');
     fireEvent.blur(pageElements.delayWhenEnters.getDelayTextBox());
     expect(
       pageElements.delayWhenEnters
@@ -147,9 +144,7 @@ describe('enters viewport event view', () => {
     fireEvent.click(pageElements.delayWhenEnters.radioGroup.getAfterDelay());
 
     fireEvent.focus(pageElements.delayWhenEnters.getDelayTextBox());
-    fireEvent.change(pageElements.delayWhenEnters.getDelayTextBox(), {
-      target: { value: '0' }
-    });
+    userEvent.type(pageElements.delayWhenEnters.getDelayTextBox(), '0');
     fireEvent.blur(pageElements.delayWhenEnters.getDelayTextBox());
     expect(
       pageElements.delayWhenEnters
@@ -172,9 +167,10 @@ describe('enters viewport event view', () => {
     fireEvent.click(pageElements.delayWhenEnters.radioGroup.getAfterDelay());
 
     fireEvent.focus(pageElements.delayWhenEnters.getDelayTextBox());
-    fireEvent.change(pageElements.delayWhenEnters.getDelayTextBox(), {
-      target: { value: '%Data Element 1%' }
-    });
+    userEvent.type(
+      pageElements.delayWhenEnters.getDelayTextBox(),
+      '%Data Element 1%'
+    );
     fireEvent.blur(pageElements.delayWhenEnters.getDelayTextBox());
 
     expect(
@@ -182,5 +178,7 @@ describe('enters viewport event view', () => {
         .getDelayTextBox()
         .hasAttribute('aria-invalid')
     ).toBeFalse();
+
+    expect(extensionBridge.getSettings().delay).toBe('%Data Element 1%');
   });
 });

--- a/src/view/events/__tests__/hover.test.jsx
+++ b/src/view/events/__tests__/hover.test.jsx
@@ -11,6 +11,7 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { sharedTestingElements } from '@test-helpers/react-testing-library';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import Hover, { formConfig } from '../hover';
@@ -90,17 +91,13 @@ describe('hover event view', () => {
   });
 
   it('sets settings from form values', () => {
-    fireEvent.change(
+    userEvent.type(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox(),
-      {
-        target: { value: '.foo' }
-      }
+      '.foo'
     );
 
     fireEvent.click(pageElements.delayHover.radioGroup.getAfterDelay());
-    fireEvent.change(pageElements.delayHover.getDelayTextBox(), {
-      target: { value: '100' }
-    });
+    userEvent.type(pageElements.delayHover.getDelayTextBox(), '100');
 
     fireEvent.click(sharedTestingElements.advancedSettings.getToggleTrigger());
     fireEvent.click(
@@ -151,9 +148,7 @@ describe('hover event view', () => {
     fireEvent.click(pageElements.delayHover.radioGroup.getAfterDelay());
 
     fireEvent.focus(pageElements.delayHover.getDelayTextBox());
-    fireEvent.change(pageElements.delayHover.getDelayTextBox(), {
-      target: { value: '0' }
-    });
+    userEvent.type(pageElements.delayHover.getDelayTextBox(), '0');
     fireEvent.blur(pageElements.delayHover.getDelayTextBox());
 
     expect(
@@ -175,13 +170,16 @@ describe('hover event view', () => {
     fireEvent.click(pageElements.delayHover.radioGroup.getAfterDelay());
 
     fireEvent.focus(pageElements.delayHover.getDelayTextBox());
-    fireEvent.change(pageElements.delayHover.getDelayTextBox(), {
-      target: { value: '%Data Element 1%' }
-    });
+    userEvent.type(
+      pageElements.delayHover.getDelayTextBox(),
+      '%Data Element 1%'
+    );
     fireEvent.blur(pageElements.delayHover.getDelayTextBox());
 
     expect(
       pageElements.delayHover.getDelayTextBox().getAttribute('aria-invalid')
     ).toBeFalsy();
+
+    expect(extensionBridge.getSettings().delay).toBe('%Data Element 1%');
   });
 });

--- a/src/view/events/__tests__/mediaTimePlayed.test.jsx
+++ b/src/view/events/__tests__/mediaTimePlayed.test.jsx
@@ -11,6 +11,7 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   clickSpectrumOption,
   sharedTestingElements
@@ -81,16 +82,11 @@ describe('time played event view', () => {
   });
 
   it('sets settings from form values', async () => {
-    fireEvent.change(
+    userEvent.type(
       sharedTestingElements.elementsMatching.getCssSelectorTextBox(),
-      {
-        target: { value: '.foo' }
-      }
+      '.foo'
     );
-
-    fireEvent.change(pageElements.triggerWhen.getTextBox(), {
-      target: { value: '45' }
-    });
+    userEvent.type(pageElements.triggerWhen.getTextBox(), '45');
 
     fireEvent.click(sharedTestingElements.advancedSettings.getToggleTrigger());
     fireEvent.click(
@@ -149,13 +145,13 @@ describe('time played event view', () => {
 
   it('media amount handles data element names just fine', () => {
     fireEvent.focus(pageElements.triggerWhen.getTextBox());
-    fireEvent.change(pageElements.triggerWhen.getTextBox(), {
-      target: { value: '%Data Element 1%' }
-    });
+    userEvent.type(pageElements.triggerWhen.getTextBox(), '%Data Element 1%');
     fireEvent.blur(pageElements.triggerWhen.getTextBox());
 
     expect(
       pageElements.triggerWhen.getTextBox().hasAttribute('aria-invalid')
     ).toBeFalse();
+
+    expect(extensionBridge.getSettings().amount).toBe('%Data Element 1%');
   });
 });

--- a/src/view/events/__tests__/timeOnPage.test.jsx
+++ b/src/view/events/__tests__/timeOnPage.test.jsx
@@ -11,6 +11,7 @@
  ****************************************************************************************/
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import TimeOnPage, { formConfig } from '../timeOnPage';
 import bootstrap from '../../bootstrap';
@@ -51,9 +52,7 @@ describe('time on page event view', () => {
 
   it('sets settings from form values', () => {
     fireEvent.focus(pageElements.timeOnPage.getTextBox());
-    fireEvent.change(pageElements.timeOnPage.getTextBox(), {
-      target: { value: '55' }
-    });
+    userEvent.type(pageElements.timeOnPage.getTextBox(), '55');
     fireEvent.blur(pageElements.timeOnPage.getTextBox());
     expect(
       pageElements.timeOnPage.getTextBox().hasAttribute('aria-invalid')
@@ -74,9 +73,7 @@ describe('time on page event view', () => {
 
   it('sets error if timeOnPage value is not a number', () => {
     fireEvent.focus(pageElements.timeOnPage.getTextBox());
-    fireEvent.change(pageElements.timeOnPage.getTextBox(), {
-      target: { value: '12.abc' }
-    });
+    userEvent.type(pageElements.timeOnPage.getTextBox(), '12.abc');
     fireEvent.blur(pageElements.timeOnPage.getTextBox());
     expect(
       pageElements.timeOnPage.getTextBox().hasAttribute('aria-invalid')
@@ -91,9 +88,7 @@ describe('time on page event view', () => {
     ).toBeFalse();
 
     fireEvent.focus(pageElements.timeOnPage.getTextBox());
-    fireEvent.change(pageElements.timeOnPage.getTextBox(), {
-      target: { value: '0' }
-    });
+    userEvent.type(pageElements.timeOnPage.getTextBox(), '0');
     fireEvent.blur(pageElements.timeOnPage.getTextBox());
 
     expect(
@@ -112,13 +107,13 @@ describe('time on page event view', () => {
 
   it('timeOnPage handles data element names just fine', () => {
     fireEvent.focus(pageElements.timeOnPage.getTextBox());
-    fireEvent.change(pageElements.timeOnPage.getTextBox(), {
-      target: { value: '%Data Element 1%' }
-    });
+    userEvent.type(pageElements.timeOnPage.getTextBox(), '%Data Element 1%');
     fireEvent.blur(pageElements.timeOnPage.getTextBox());
 
     expect(
       pageElements.timeOnPage.getTextBox().hasAttribute('aria-invalid')
     ).toBeFalse();
+
+    expect(extensionBridge.getSettings().timeOnPage).toBe('%Data Element 1%');
   });
 });

--- a/src/view/events/click.jsx
+++ b/src/view/events/click.jsx
@@ -59,6 +59,8 @@ export default connect((state) => ({
   )
 }))(Click);
 
+const minNumberOptions = { min: 1 };
+
 export const formConfig = mergeFormConfigs(
   elementFilterFormConfig,
   advancedEventOptionsFormConfig,
@@ -81,7 +83,9 @@ export const formConfig = mergeFormConfigs(
     formValuesToSettings: (settings, values) => {
       const newSettings = {
         ...settings,
-        anchorDelay: Number(values.anchorDelay)
+        anchorDelay: isNumberLikeInRange(values.anchorDelay, minNumberOptions)
+          ? Number(values.anchorDelay)
+          : String(values.anchorDelay)
       };
 
       if (!values.delayLinkActivation) {
@@ -97,7 +101,7 @@ export const formConfig = mergeFormConfigs(
 
       if (
         values.delayLinkActivation &&
-        !isNumberLikeInRange(values.anchorDelay, { min: 1 }) &&
+        !isNumberLikeInRange(values.anchorDelay, minNumberOptions) &&
         !isDataElementToken(values.anchorDelay)
       ) {
         errors.anchorDelay =

--- a/src/view/events/components/delayType.jsx
+++ b/src/view/events/components/delayType.jsx
@@ -56,6 +56,8 @@ const stateToProps = (state) => ({
 
 export default connect(stateToProps)(DelayType);
 
+const minNumberOptions = { min: 1 };
+
 export const formConfig = {
   settingsToFormValues(values, settings) {
     return {
@@ -70,7 +72,9 @@ export const formConfig = {
     };
 
     if (values.delayType === 'delay') {
-      settings.delay = Number(values.delay);
+      settings.delay = isNumberLikeInRange(values.delay, minNumberOptions)
+        ? Number(values.delay)
+        : String(values.delay);
     }
 
     return settings;
@@ -82,7 +86,7 @@ export const formConfig = {
 
     if (
       values.delayType === 'delay' &&
-      !isNumberLikeInRange(values.delay, { min: 1 }) &&
+      !isNumberLikeInRange(values.delay, minNumberOptions) &&
       !isDataElementToken(values.delay)
     ) {
       errors.delay =

--- a/src/view/events/mediaTimePlayed.jsx
+++ b/src/view/events/mediaTimePlayed.jsx
@@ -77,6 +77,8 @@ const MediaTimePlayed = () => (
 
 export default MediaTimePlayed;
 
+const minNumberOptions = { min: 1 };
+
 export const formConfig = mergeFormConfigs(
   elementFilterFormConfig,
   advancedEventOptionsFormConfig,
@@ -88,7 +90,9 @@ export const formConfig = mergeFormConfigs(
     formValuesToSettings: (settings, values) => ({
       ...settings,
       unit: values.unit,
-      amount: Number(values.amount)
+      amount: isNumberLikeInRange(values.amount, minNumberOptions)
+        ? Number(values.amount)
+        : String(values.amount)
     }),
     validate: (errors, values) => {
       errors = {
@@ -96,7 +100,7 @@ export const formConfig = mergeFormConfigs(
       };
 
       if (
-        !isNumberLikeInRange(values.amount, { min: 0, minInclusive: false }) &&
+        !isNumberLikeInRange(values.amount, minNumberOptions) &&
         !isDataElementToken(values.amount)
       ) {
         errors.amount =

--- a/src/view/events/timeOnPage.jsx
+++ b/src/view/events/timeOnPage.jsx
@@ -32,6 +32,8 @@ const TimeOnPage = () => (
 
 export default TimeOnPage;
 
+const minNumberOptions = { min: 1 };
+
 export const formConfig = {
   settingsToFormValues(values, settings) {
     return {
@@ -41,7 +43,9 @@ export const formConfig = {
   },
   formValuesToSettings: (settings, values) => ({
     ...settings,
-    timeOnPage: Number(values.timeOnPage)
+    timeOnPage: isNumberLikeInRange(values.timeOnPage, minNumberOptions)
+      ? Number(values.timeOnPage)
+      : String(values.timeOnPage)
   }),
   validate: (errors, values) => {
     errors = {
@@ -49,7 +53,7 @@ export const formConfig = {
     };
 
     if (
-      !isNumberLikeInRange(values.timeOnPage, { min: 1 }) &&
+      !isNumberLikeInRange(values.timeOnPage, minNumberOptions) &&
       !isDataElementToken(values.timeOnPage)
     ) {
       errors.timeOnPage =


### PR DESCRIPTION
DTM-13847:

1. Fix the new Data Element supported fields to
properly translate the value within "formValuesToSettings" blocks.
2. Consolidate simulate.clear into the test-helpers area.
3. Update old fireEvent.change calls to userEvent.type calls.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
There wasn't enough test coverage to ensure that when translating the formValues into turbine settings, that the data element names weren't always converted to a Number.

## Related Issue

https://jira.corp.adobe.com/browse/DTM-13847

## Motivation and Context

Adds data element support to many core extension fields that only supported numbers.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
