### PR TITLE
DTM-13847: coerce runtime strings to numbers

### DIFF
--- a/src/lib/conditions/__tests__/timeOnSite.test.js
+++ b/src/lib/conditions/__tests__/timeOnSite.test.js
@@ -36,6 +36,15 @@ describe('time on site condition delegate', function () {
     expect(conditionDelegate(settings)).toBe(true);
   });
 
+  it(
+    'returns true when number of minutes is above "greater than" ' +
+      'constraint (as a string)',
+    function () {
+      var settings = getSettings('4', '>');
+      expect(conditionDelegate(settings)).toBe(true);
+    }
+  );
+
   it('returns false when number of minutes is below "greater than" constraint', function () {
     var settings = getSettings(6, '>');
     expect(conditionDelegate(settings)).toBe(false);
@@ -45,6 +54,15 @@ describe('time on site condition delegate', function () {
     var settings = getSettings(6, '<');
     expect(conditionDelegate(settings)).toBe(true);
   });
+
+  it(
+    'returns true when number of minutes is below "less than" constraint ' +
+      '(as a string)',
+    function () {
+      var settings = getSettings('6', '<');
+      expect(conditionDelegate(settings)).toBe(true);
+    }
+  );
 
   it('returns false when number of minutes is above "less than" constraint', function () {
     var settings = getSettings(4, '<');

--- a/src/lib/conditions/timeOnSite.js
+++ b/src/lib/conditions/timeOnSite.js
@@ -14,6 +14,8 @@
 
 var visitorTracking = require('../helpers/visitorTracking');
 var compareNumbers = require('./helpers/compareNumbers');
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 
 /**
  * Time on site condition. Determines if the user has been on the site for a certain amount
@@ -28,6 +30,6 @@ module.exports = function (settings) {
   return compareNumbers(
     visitorTracking.getMinutesOnSite(),
     settings.operator,
-    settings.minutes
+    castToNumberIfString(settings.minutes)
   );
 };

--- a/src/lib/conditions/valueComparison.js
+++ b/src/lib/conditions/valueComparison.js
@@ -13,24 +13,15 @@
 /*eslint eqeqeq:0*/
 'use strict';
 
-var isNumber = function (value) {
-  return typeof value === 'number' && isFinite(value); // isFinite weeds out NaNs.
-};
-
-var isString = function (value) {
-  return typeof value === 'string' || value instanceof String;
-};
+var isString = require('../helpers/stringAndNumberUtils').isString;
+var isNumber = require('../helpers/stringAndNumberUtils').isNumber;
+var castToStringIfNumber = require('../helpers/stringAndNumberUtils')
+  .castToStringIfNumber;
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 
 var updateCase = function (operand, caseInsensitive) {
   return caseInsensitive && isString(operand) ? operand.toLowerCase() : operand;
-};
-
-var castToStringIfNumber = function (operand) {
-  return isNumber(operand) ? String(operand) : operand;
-};
-
-var castToNumberIfString = function (operand) {
-  return isString(operand) ? Number(operand) : operand;
 };
 
 var guardStringCompare = function (compare) {

--- a/src/lib/events/__tests__/click.test.js
+++ b/src/lib/events/__tests__/click.test.js
@@ -300,6 +300,21 @@ describe('click event delegate', function () {
       expect(defaultPrevented).toBe(true);
     });
 
+    it('delays navigation if anchorDelay is a string', function () {
+      link.setAttribute('target', '_top');
+
+      delegate(
+        {
+          anchorDelay: '100'
+        },
+        triggerSpy
+      );
+
+      link.click();
+
+      expect(defaultPrevented).toBe(true);
+    });
+
     it('does not delay navigation if the link has target=_parent', function () {
       link.setAttribute('target', '_parent');
 

--- a/src/lib/events/__tests__/entersViewport.test.js
+++ b/src/lib/events/__tests__/entersViewport.test.js
@@ -170,6 +170,33 @@ describe('enters viewport event delegate', function () {
       expect(a2Trigger.calls.count()).toEqual(1);
     });
 
+    it('handles settings.delay as a string', function () {
+      var trigger = jasmine.createSpy();
+
+      delegate(
+        {
+          elementSelector: 'div',
+          elementProperties: [
+            {
+              name: 'customProp',
+              value: 'foo'
+            }
+          ],
+          delay: '100'
+        },
+        trigger
+      );
+
+      jasmine.clock().tick(POLL_INTERVAL);
+
+      assertTriggerCall({
+        call: trigger.calls.first(),
+        element: aElement,
+        target: aElement,
+        delay: 100
+      });
+    });
+
     it('triggers multiple rules targeting the same element with same delay', function () {
       var aTrigger = jasmine.createSpy();
       var a2Trigger = jasmine.createSpy();

--- a/src/lib/events/__tests__/hover.test.js
+++ b/src/lib/events/__tests__/hover.test.js
@@ -66,6 +66,40 @@ describe('hover event delegate', function () {
     liveQuerySelector.__reset();
   });
 
+  it(
+    'can properly parse settings.delay when it is a string ' +
+      '(from data element value)',
+    function () {
+      var trigger = jasmine.createSpy();
+
+      delegate(
+        {
+          elementSelector: '#a',
+          bubbleFireIfParent: true,
+          bubbleFireIfChildFired: true,
+          bubbleStop: false,
+          delay: '1000'
+        },
+        trigger
+      );
+
+      jasmine.clock().tick(POLL_INTERVAL);
+
+      Simulate.mouseenter(aElement);
+
+      jasmine.clock().tick(1100);
+
+      expect(trigger.calls.count()).toEqual(1);
+
+      assertTriggerCall({
+        call: trigger.calls.mostRecent(),
+        element: aElement,
+        target: aElement,
+        delay: 1000 // the string was properly parsed to a number
+      });
+    }
+  );
+
   it('triggers multiple rules with no delay targeting nested elements', function () {
     var aTrigger = jasmine.createSpy();
     var bTrigger = jasmine.createSpy();

--- a/src/lib/events/__tests__/mediaTimePlayed.test.js
+++ b/src/lib/events/__tests__/mediaTimePlayed.test.js
@@ -217,6 +217,83 @@ describe('media time played event delegate', function () {
   );
 
   it(
+    'triggers multiple rules with the same amount using second unit targeting ' +
+      'nested elements (as strings)',
+    function () {
+      var aTrigger = jasmine.createSpy();
+      var bTrigger = jasmine.createSpy();
+
+      delegate(
+        {
+          elementSelector: '#a',
+          amount: '5',
+          unit: 'second',
+          bubbleFireIfParent: true,
+          bubbleFireIfChildFired: true,
+          bubbleStop: false
+        },
+        aTrigger
+      );
+
+      delegate(
+        {
+          elementSelector: '#b',
+          amount: '5',
+          unit: 'second',
+          bubbleFireIfParent: true,
+          bubbleFireIfChildFired: true,
+          bubbleStop: false
+        },
+        bTrigger
+      );
+
+      expect(aTrigger.calls.count()).toEqual(0);
+      expect(bTrigger.calls.count()).toEqual(0);
+
+      var seekable = {
+        start: function () {
+          return 30;
+        },
+        end: function () {
+          return 100;
+        },
+        length: 1
+      };
+
+      bElement.seekable = seekable;
+      bElement.currentTime = 34;
+
+      Simulate.timeupdate(bElement);
+
+      expect(aTrigger.calls.count()).toEqual(0);
+      expect(bTrigger.calls.count()).toEqual(0);
+
+      bElement.currentTime = 35;
+
+      Simulate.timeupdate(bElement);
+
+      expect(aTrigger.calls.count()).toEqual(1);
+      expect(bTrigger.calls.count()).toEqual(1);
+
+      assertTriggerCall({
+        call: aTrigger.calls.first(),
+        element: aElement,
+        target: bElement,
+        amount: 5,
+        unit: 'second'
+      });
+
+      assertTriggerCall({
+        call: bTrigger.calls.first(),
+        element: bElement,
+        target: bElement,
+        amount: 5,
+        unit: 'second'
+      });
+    }
+  );
+
+  it(
     'triggers multiple rules with the different amounts using second unit targeting nested ' +
       'elements',
     function () {

--- a/src/lib/events/__tests__/timeOnPage.test.js
+++ b/src/lib/events/__tests__/timeOnPage.test.js
@@ -65,6 +65,18 @@ describe('time on page event delegate', function () {
     });
   });
 
+  it('triggers rule when timeOnPage is a string', function () {
+    var trigger = jasmine.createSpy('timeOnPageTrigger');
+
+    delegate({ timeOnPage: '2' }, trigger);
+    jasmine.clock().tick(2000);
+
+    var call = trigger.calls.mostRecent();
+    expect(call.args[0]).toEqual({
+      timeOnPage: 2
+    });
+  });
+
   if (!isIE() || isIE() > 9) {
     it('stops the timer on tab blur', function () {
       spyOn(Timer.prototype, 'pause');

--- a/src/lib/events/click.js
+++ b/src/lib/events/click.js
@@ -17,6 +17,8 @@ var bubbly = require('./helpers/createBubbly')();
 var WeakMap = require('./helpers/weakMap');
 var evaluatedEvents = new WeakMap();
 var MIDDLE_MOUSE_BUTTON = 2;
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 
 /**
  * Determines whether an element is a link that would navigate the user's current window to a
@@ -67,7 +69,7 @@ document.addEventListener('click', bubbly.evaluateEvent, true);
  * for the rule to fire.
  * @param {string} settings.elementProperties[].name - The property name.
  * @param {string} settings.elementProperties[].value - The property value.
- * @param {number} [settings.anchorDelay] - When present and a link is clicked, actual
+ * @param {number|string} [settings.anchorDelay] - When present and a link is clicked, actual
  * navigation will be postponed for a period of time equal with its value. This is typically used to
  * allow time for scripts within the rule to execute, beacons to be sent to servers, etc.
  * @param {boolean} settings.elementProperties[].valueIsRegex=false - Whether <code>value</code>
@@ -96,14 +98,15 @@ module.exports = function (settings, trigger) {
       return;
     }
 
-    if (settings.anchorDelay) {
+    var anchorDelay = castToNumberIfString(settings.anchorDelay);
+    if (anchorDelay) {
       if (!evaluatedEvents.has(nativeEvent)) {
         var delayableLink = getDelayableLink(nativeEvent);
         if (delayableLink) {
           nativeEvent.preventDefault();
           setTimeout(function () {
             window.location = delayableLink.href;
-          }, settings.anchorDelay);
+          }, anchorDelay);
         }
         evaluatedEvents.set(nativeEvent, true);
       }

--- a/src/lib/events/entersViewport.js
+++ b/src/lib/events/entersViewport.js
@@ -19,6 +19,8 @@ var debounce = require('./helpers/debounce');
 var enableWeakMapDefaultValue = require('./helpers/enableWeakMapDefaultValue');
 var matchesSelector = require('./helpers/matchesSelector');
 var matchesProperties = require('./helpers/matchesProperties');
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 
 var POLL_INTERVAL = 3000;
 var DEBOUNCE_DELAY = 200;
@@ -266,7 +268,7 @@ if (isIE10) {
  * @param {string} settings.elementProperties[].value The property value.
  * @param {boolean} [settings.elementProperties[].valueIsRegex=false] Whether <code>value</code>
  * on the object instance is intended to be a regular expression.
- * @param {number} [settings.delay] The number of milliseconds the element must be
+ * @param {number|string} [settings.delay] The number of milliseconds the element must be
  * within the viewport before declaring that the event has occurred.
  * @param {ruleTrigger} trigger The trigger callback.
  */
@@ -277,6 +279,7 @@ module.exports = function (settings, trigger) {
     listeners = listenersBySelector[settings.elementSelector] = [];
   }
 
+  settings.delay = castToNumberIfString(settings.delay);
   listeners.push({
     settings: settings,
     trigger: trigger

--- a/src/lib/events/hover.js
+++ b/src/lib/events/hover.js
@@ -17,6 +17,8 @@ var liveQuerySelector = require('./helpers/liveQuerySelector');
 var matchesProperties = require('./helpers/matchesProperties');
 var WeakMap = require('./helpers/weakMap');
 var trackedDelaysByElement = new WeakMap();
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 
 /**
  * After a mouseenter has occurred, waits a given amount of time before declaring that a hover
@@ -81,7 +83,7 @@ var watchElement = function (element, trackedDelays) {
  * @param {string} settings.elementProperties[].value The property value.
  * @param {boolean} [settings.elementProperties[].valueIsRegex=false] Whether <code>value</code>
  * on the object instance is intended to be a regular expression.
- * @param {number} [settings.delay] The number of milliseconds the pointer must be on
+ * @param {number|string} [settings.delay] The number of milliseconds the pointer must be on
  * top of the element before declaring that a hover has occurred.
  * @param {boolean} [settings.bubbleFireIfParent=true] Whether the rule should fire
  * if the event originated from a descendant element.
@@ -92,7 +94,8 @@ var watchElement = function (element, trackedDelays) {
  * @param {ruleTrigger} trigger The trigger callback.
  */
 module.exports = function (settings, trigger) {
-  var delay = settings.delay || 0;
+  // if settings.delay can't be parsed, fall back to no delay
+  var delay = castToNumberIfString(settings.delay) || 0;
 
   bubbly.addListener(settings, function (syntheticEvent) {
     // Bubbling for this event is dependent upon the delay configured for rules.

--- a/src/lib/events/mediaTimePlayed.js
+++ b/src/lib/events/mediaTimePlayed.js
@@ -14,6 +14,8 @@
 
 var bubbly = require('./helpers/createBubbly')();
 var WeakMap = require('./helpers/weakMap');
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 var lastTriggeredByElement = new WeakMap();
 
 var relevantMarkers = [];
@@ -79,7 +81,7 @@ document.addEventListener('timeupdate', handleTimeUpdate, true);
  * @param {string} settings.elementProperties[].value The property value.
  * @param {boolean} [settings.elementProperties[].valueIsRegex=false] Whether <code>value</code>
  * on the object instance is intended to be a regular expression.
- * @param {number} settings.amount The amount of time the media must be played before
+ * @param {number|string} settings.amount The amount of time the media must be played before
  * this event is fired. This value may either be number of seconds (20 for 20 seconds) or a
  * percent value (20 for 20%).
  * @param {timePlayedUnit} settings.unit The unit of duration measurement.
@@ -92,25 +94,28 @@ document.addEventListener('timeupdate', handleTimeUpdate, true);
  * @param {ruleTrigger} trigger The trigger callback.
  */
 module.exports = function (settings, trigger) {
+  var amount = castToNumberIfString(settings.amount);
+
   var doesMarkerMatch = function (marker) {
-    return marker.amount === settings.amount && marker.unit === settings.unit;
+    return marker.amount === amount && marker.unit === settings.unit;
   };
 
   var markerRegistered = relevantMarkers.some(doesMarkerMatch);
 
   if (!markerRegistered) {
     relevantMarkers.push({
-      amount: settings.amount,
+      amount: amount,
       unit: settings.unit
     });
   }
 
   bubbly.addListener(settings, function (syntheticEvent) {
+    var amount = castToNumberIfString(settings.amount);
     // Bubbling for this event is dependent upon the amount and unit configured for rules.
     // An event can "bubble up" to other rules with the same amount and unit but not to rules with
     // a different amount or unit. See the tests for how this plays out.
     if (
-      syntheticEvent.amount === settings.amount &&
+      syntheticEvent.amount === amount &&
       syntheticEvent.unit === settings.unit
     ) {
       trigger(syntheticEvent);

--- a/src/lib/events/timeOnPage.js
+++ b/src/lib/events/timeOnPage.js
@@ -15,6 +15,8 @@ var document = require('@adobe/reactor-document');
 var once = require('./helpers/once');
 var visibilityApi = require('./helpers/visibilityApi')();
 var Timer = require('./helpers/timer');
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
 
 var hiddenProperty = visibilityApi.hiddenProperty;
 var visibilityChangeEventType = visibilityApi.visibilityChangeEventType;
@@ -56,13 +58,13 @@ var setupTimer = once(function () {
  * passes the provided markers. The timer will be paused whenever the user will switch to another
  * tab and it will be resumed when the user returns back to the tab.
  * @param {Object} settings The event settings object.
- * @param {number} settings.timeOnPage The number of seconds the user must be on the page
+ * @param {number|string} settings.timeOnPage The number of seconds the user must be on the page
  * before the rule is triggered.
  * @param {ruleTrigger} trigger The trigger callback.
  */
 module.exports = function (settings, trigger) {
   var timer = setupTimer();
-  var timeOnPageMilliseconds = settings.timeOnPage * 1000;
+  var timeOnPageMilliseconds = castToNumberIfString(settings.timeOnPage) * 1000;
 
   timer.addMarker(timeOnPageMilliseconds);
 

--- a/src/lib/helpers/stringAndNumberUtils.js
+++ b/src/lib/helpers/stringAndNumberUtils.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var isNumber = function (value) {
+  return typeof value === 'number' && isFinite(value); // isFinite weeds out NaNs.
+};
+
+var isString = function (value) {
+  return typeof value === 'string' || value instanceof String;
+};
+
+var castToStringIfNumber = function (value) {
+  return isNumber(value) ? String(value) : value;
+};
+
+var castToNumberIfString = function (value) {
+  return isString(value) ? Number(value) : value;
+};
+
+module.exports = {
+  isNumber: isNumber,
+  isString: isString,
+  castToStringIfNumber: castToStringIfNumber,
+  castToNumberIfString: castToNumberIfString
+};


### PR DESCRIPTION
DTM-13847: update runtime code to ensure new data element values are coerced to numbers when appropriate

<!--- Provide a general summary of your changes in the Title above -->

## Description

There can be unforseen consequences of leaving the translated settings to values as strings when the data element values aren't coerced.

## Related Issue

https://jira.corp.adobe.com/browse/DTM-13847

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
