### PR TITLE
PDCL-4859: fix warning icons getting crushed in views

### DIFF
--- a/src/view/components/helpText.jsx
+++ b/src/view/components/helpText.jsx
@@ -19,7 +19,7 @@ export default ({ color = 'notice', children, ...containerProps }) => (
       // for when spectrum views support color slot context...
       color={color}
     >
-      <Flex gap="size-100">
+      <Flex gap="size-100" UNSAFE_className="warning-container-content">
         <Alert
           aria-label="Alert"
           size="S"

--- a/src/view/components/helpText.styl
+++ b/src/view/components/helpText.styl
@@ -1,3 +1,9 @@
 .spectrum-semantic-negative-color-text-small {
   color: var(--spectrum-semantic-negative-color-text-small);
 }
+
+.warning-container-content {
+  svg {
+    flex-shrink: 0;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When the `helpText` warning container was introduced, care was not taken to ensure that shrinking the viewable space didn't shrink the icon.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-4859

## Motivation and Context

Easy to notice in Lens since the viewable space is smaller than the entire screen.


## Screenshots (if appropriate):

### Before

![Screen Shot 2021-04-23 at 4 06 42 PM](https://user-images.githubusercontent.com/1789219/115934298-f4b6f480-a44d-11eb-93d1-c5482564aa90.png)

### After

![Screen Shot 2021-04-23 at 4 06 50 PM](https://user-images.githubusercontent.com/1789219/115934322-00a2b680-a44e-11eb-8f6a-38e6f7b3aa2c.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
