### PR TITLE
Adding new Data Elements to reduce the need for Custom Code

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -58,7 +58,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -105,7 +108,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -158,7 +164,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -202,13 +211,17 @@
           }
         },
         "additionalProperties": false,
-        "required": ["source"]
+        "required": [
+          "source"
+        ]
       },
       "transforms": [
         {
           "type": "function",
           "propertyPath": "source",
-          "parameters": ["trigger"]
+          "parameters": [
+            "trigger"
+          ]
         }
       ]
     },
@@ -247,7 +260,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -261,7 +277,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       }
     },
     {
@@ -280,7 +298,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       }
     },
     {
@@ -299,7 +319,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       }
     },
     {
@@ -340,12 +362,17 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           }
         },
         "additionalProperties": false,
-        "required": ["elementSelector"]
+        "required": [
+          "elementSelector"
+        ]
       }
     },
     {
@@ -379,7 +406,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -426,7 +456,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "delay": {
@@ -443,11 +476,16 @@
           },
           "frequency": {
             "type": "string",
-            "enum": ["firstEntry", "everyEntry"]
+            "enum": [
+              "firstEntry",
+              "everyEntry"
+            ]
           }
         },
         "additionalProperties": false,
-        "required": ["elementSelector"]
+        "required": [
+          "elementSelector"
+        ]
       }
     },
     {
@@ -481,7 +519,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -528,7 +569,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -554,7 +598,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["elementSelector"]
+        "required": [
+          "elementSelector"
+        ]
       }
     },
     {
@@ -588,7 +634,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -635,7 +684,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -689,7 +741,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -764,7 +819,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -811,7 +869,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -858,7 +919,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -905,7 +969,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -959,7 +1026,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["timeOnPage"]
+        "required": [
+          "timeOnPage"
+        ]
       }
     },
     {
@@ -993,7 +1062,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -1019,11 +1091,17 @@
           },
           "unit": {
             "type": "string",
-            "enum": ["percent", "second"]
+            "enum": [
+              "percent",
+              "second"
+            ]
           }
         },
         "additionalProperties": false,
-        "required": ["amount", "unit"]
+        "required": [
+          "amount",
+          "unit"
+        ]
       }
     },
     {
@@ -1057,7 +1135,10 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "bubbleFireIfParent": {
@@ -1108,7 +1189,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["browsers"]
+        "required": [
+          "browsers"
+        ]
       }
     },
     {
@@ -1133,7 +1216,10 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       }
     },
     {
@@ -1152,13 +1238,18 @@
           }
         },
         "additionalProperties": false,
-        "required": ["source"]
+        "required": [
+          "source"
+        ]
       },
       "transforms": [
         {
           "type": "function",
           "propertyPath": "source",
-          "parameters": ["event", "target"]
+          "parameters": [
+            "event",
+            "target"
+          ]
         }
       ]
     },
@@ -1221,7 +1312,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["deviceTypes"]
+        "required": [
+          "deviceTypes"
+        ]
       }
     },
     {
@@ -1242,7 +1335,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["domains"]
+        "required": [
+          "domains"
+        ]
       }
     },
     {
@@ -1269,13 +1364,17 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["value"]
+              "required": [
+                "value"
+              ]
             },
             "minItems": 1
           }
         },
         "additionalProperties": false,
-        "required": ["hashes"]
+        "required": [
+          "hashes"
+        ]
       }
     },
     {
@@ -1297,7 +1396,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["page"]
+        "required": [
+          "page"
+        ]
       }
     },
     {
@@ -1331,17 +1432,24 @@
               }
             },
             "additionalProperties": false,
-            "required": ["count", "unit"]
+            "required": [
+              "count",
+              "unit"
+            ]
           },
           {
             "properties": {
               "unit": {
                 "type": "string",
-                "enum": ["visitor"]
+                "enum": [
+                  "visitor"
+                ]
               }
             },
             "additionalProperties": false,
-            "required": ["unit"]
+            "required": [
+              "unit"
+            ]
           }
         ]
       }
@@ -1361,7 +1469,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["isNewVisitor"]
+        "required": [
+          "isNewVisitor"
+        ]
       }
     },
     {
@@ -1378,12 +1488,21 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["Windows", "MacOS", "Linux", "Unix", "iOS", "Android"]
+              "enum": [
+                "Windows",
+                "MacOS",
+                "Linux",
+                "Unix",
+                "iOS",
+                "Android"
+              ]
             }
           }
         },
         "additionalProperties": false,
-        "required": ["operatingSystems"]
+        "required": [
+          "operatingSystems"
+        ]
       }
     },
     {
@@ -1398,18 +1517,29 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "count": {
             "type": "number"
           },
           "duration": {
             "type": "string",
-            "enum": ["lifetime", "session"]
+            "enum": [
+              "lifetime",
+              "session"
+            ]
           }
         },
         "additionalProperties": false,
-        "required": ["operator", "count", "duration"]
+        "required": [
+          "operator",
+          "count",
+          "duration"
+        ]
       }
     },
     {
@@ -1436,13 +1566,17 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["value"]
+              "required": [
+                "value"
+              ]
             },
             "minItems": 1
           }
         },
         "additionalProperties": false,
-        "required": ["paths"]
+        "required": [
+          "paths"
+        ]
       }
     },
     {
@@ -1469,13 +1603,17 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["value"]
+              "required": [
+                "value"
+              ]
             },
             "minItems": 1
           }
         },
         "additionalProperties": false,
-        "required": ["paths"]
+        "required": [
+          "paths"
+        ]
       }
     },
     {
@@ -1490,11 +1628,16 @@
         "properties": {
           "protocol": {
             "type": "string",
-            "enum": ["http:", "https:"]
+            "enum": [
+              "http:",
+              "https:"
+            ]
           }
         },
         "additionalProperties": false,
-        "required": ["protocol"]
+        "required": [
+          "protocol"
+        ]
       }
     },
     {
@@ -1509,21 +1652,34 @@
         "properties": {
           "widthOperator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "width": {
             "type": "number"
           },
           "heightOperator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "height": {
             "type": "number"
           }
         },
         "additionalProperties": false,
-        "required": ["widthOperator", "width", "heightOperator", "height"]
+        "required": [
+          "widthOperator",
+          "width",
+          "heightOperator",
+          "height"
+        ]
       }
     },
     {
@@ -1546,7 +1702,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["rate"]
+        "required": [
+          "rate"
+        ]
       }
     },
     {
@@ -1561,14 +1719,21 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "count": {
             "type": "number"
           }
         },
         "additionalProperties": false,
-        "required": ["operator", "count"]
+        "required": [
+          "operator",
+          "count"
+        ]
       }
     },
     {
@@ -1595,13 +1760,17 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["value"]
+              "required": [
+                "value"
+              ]
             },
             "minItems": 1
           }
         },
         "additionalProperties": false,
-        "required": ["subdomains"]
+        "required": [
+          "subdomains"
+        ]
       }
     },
     {
@@ -1616,7 +1785,11 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "minutes": {
             "oneOf": [
@@ -1631,7 +1804,10 @@
           }
         },
         "additionalProperties": false,
-        "required": ["operator", "minutes"]
+        "required": [
+          "operator",
+          "minutes"
+        ]
       }
     },
     {
@@ -1653,7 +1829,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["source"]
+        "required": [
+          "source"
+        ]
       }
     },
     {
@@ -1679,7 +1857,10 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       }
     },
     {
@@ -1703,13 +1884,18 @@
                 "properties": {
                   "operator": {
                     "type": "string",
-                    "enum": ["equals", "doesNotEqual"]
+                    "enum": [
+                      "equals",
+                      "doesNotEqual"
+                    ]
                   },
                   "caseInsensitive": {
                     "type": "boolean"
                   }
                 },
-                "required": ["operator"],
+                "required": [
+                  "operator"
+                ],
                 "additionalProperties": false
               },
               "rightOperand": {
@@ -1723,7 +1909,11 @@
                 ]
               }
             },
-            "required": ["leftOperand", "comparison", "rightOperand"],
+            "required": [
+              "leftOperand",
+              "comparison",
+              "rightOperand"
+            ],
             "additionalProperties": false
           },
           {
@@ -1752,7 +1942,9 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["operator"],
+                "required": [
+                  "operator"
+                ],
                 "additionalProperties": false
               },
               "rightOperand": {
@@ -1760,7 +1952,11 @@
                 "minLength": 1
               }
             },
-            "required": ["leftOperand", "comparison", "rightOperand"],
+            "required": [
+              "leftOperand",
+              "comparison",
+              "rightOperand"
+            ],
             "additionalProperties": false
           },
           {
@@ -1782,7 +1978,9 @@
                     ]
                   }
                 },
-                "required": ["operator"],
+                "required": [
+                  "operator"
+                ],
                 "additionalProperties": false
               },
               "rightOperand": {
@@ -1797,7 +1995,11 @@
                 ]
               }
             },
-            "required": ["leftOperand", "comparison", "rightOperand"],
+            "required": [
+              "leftOperand",
+              "comparison",
+              "rightOperand"
+            ],
             "additionalProperties": false
           },
           {
@@ -1811,14 +2013,24 @@
                 "properties": {
                   "operator": {
                     "type": "string",
-                    "enum": ["isTrue", "isTruthy", "isFalse", "isFalsy"]
+                    "enum": [
+                      "isTrue",
+                      "isTruthy",
+                      "isFalse",
+                      "isFalsy"
+                    ]
                   }
                 },
-                "required": ["operator"],
+                "required": [
+                  "operator"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["leftOperand", "comparison"],
+            "required": [
+              "leftOperand",
+              "comparison"
+            ],
             "additionalProperties": false
           }
         ]
@@ -1847,7 +2059,10 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       }
     },
     {
@@ -1862,25 +2077,49 @@
         "properties": {
           "widthOperator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "width": {
             "type": "number"
           },
           "heightOperator": {
             "type": "string",
-            "enum": [">", "=", "<"]
+            "enum": [
+              ">",
+              "=",
+              "<"
+            ]
           },
           "height": {
             "type": "number"
           }
         },
         "additionalProperties": false,
-        "required": ["widthOperator", "width", "heightOperator", "height"]
+        "required": [
+          "widthOperator",
+          "width",
+          "heightOperator",
+          "height"
+        ]
       }
     }
   ],
   "dataElements": [
+    {
+      "displayName": "Conditional Value",
+      "name": "conditional-value",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "libPath": "src/lib/dataElements/conditionalValue.js",
+      "viewPath": "dataElements/conditionalValue.html"
+    },
     {
       "name": "constant",
       "displayName": "Constant",
@@ -1896,7 +2135,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["value"]
+        "required": [
+          "value"
+        ]
       }
     },
     {
@@ -1914,7 +2155,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       }
     },
     {
@@ -1932,13 +2175,17 @@
           }
         },
         "additionalProperties": false,
-        "required": ["source"]
+        "required": [
+          "source"
+        ]
       },
       "transforms": [
         {
           "type": "function",
           "propertyPath": "source",
-          "parameters": ["event"]
+          "parameters": [
+            "event"
+          ]
         }
       ]
     },
@@ -1961,8 +2208,22 @@
           }
         },
         "additionalProperties": false,
-        "required": ["elementSelector", "elementProperty"]
+        "required": [
+          "elementSelector",
+          "elementProperty"
+        ]
       }
+    },
+    {
+      "displayName": "Launch Environment",
+      "name": "launch-environment",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "libPath": "src/lib/dataElements/launchEnvironment.js",
+      "viewPath": "dataElements/launchEnvironment.html"
     },
     {
       "name": "local-storage",
@@ -1979,7 +2240,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       }
     },
     {
@@ -2003,7 +2266,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["attribute"]
+        "required": [
+          "attribute"
+        ]
       }
     },
     {
@@ -2024,7 +2289,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       }
     },
     {
@@ -2043,7 +2310,10 @@
             "type": "integer"
           }
         },
-        "required": ["min", "max"],
+        "required": [
+          "min",
+          "max"
+        ],
         "additionalProperties": false
       }
     },
@@ -2062,8 +2332,21 @@
           }
         },
         "additionalProperties": false,
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       }
+    },
+    {
+      "displayName": "JavaScript Tools",
+      "name": "javascript-tools",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "libPath": "src/lib/dataElements/javascriptTools.js",
+      "viewPath": "dataElements/javascriptTools.html"
     },
     {
       "name": "javascript-variable",
@@ -2080,8 +2363,21 @@
           }
         },
         "additionalProperties": false,
-        "required": ["path"]
+        "required": [
+          "path"
+        ]
       }
+    },
+    {
+      "displayName": "Visitor Attributes",
+      "name": "visitor-attributes",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "libPath": "src/lib/dataElements/visitorAttributes.js",
+      "viewPath": "dataElements/visitorAttributes.html"
     },
     {
       "name": "visitor-behavior",
@@ -2105,7 +2401,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["attribute"]
+        "required": [
+          "attribute"
+        ]
       }
     }
   ],
@@ -2122,7 +2420,9 @@
           {
             "properties": {
               "language": {
-                "enum": ["javascript"]
+                "enum": [
+                  "javascript"
+                ]
               },
               "global": {
                 "type": "boolean"
@@ -2133,12 +2433,17 @@
               }
             },
             "additionalProperties": false,
-            "required": ["language", "source"]
+            "required": [
+              "language",
+              "source"
+            ]
           },
           {
             "properties": {
               "language": {
-                "enum": ["html"]
+                "enum": [
+                  "html"
+                ]
               },
               "source": {
                 "type": "string",
@@ -2146,7 +2451,10 @@
               }
             },
             "additionalProperties": false,
-            "required": ["language", "source"]
+            "required": [
+              "language",
+              "source"
+            ]
           }
         ]
       },
@@ -2172,7 +2480,9 @@
           }
         },
         "additionalProperties": false,
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       }
     }
   ]

--- a/src/lib/dataElements/conditionalValue.js
+++ b/src/lib/dataElements/conditionalValue.js
@@ -1,0 +1,144 @@
+/***************************************************************************************
+ * (c) 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+/*eslint eqeqeq:0*/
+'use strict';
+
+var isString = require('../helpers/stringAndNumberUtils').isString;
+var isNumber = require('../helpers/stringAndNumberUtils').isNumber;
+var castToStringIfNumber = require('../helpers/stringAndNumberUtils')
+  .castToStringIfNumber;
+var castToNumberIfString = require('../helpers/stringAndNumberUtils')
+  .castToNumberIfString;
+
+var updateCase = function (operand, caseInsensitive) {
+  return caseInsensitive && isString(operand) ? operand.toLowerCase() : operand;
+};
+
+var guardStringCompare = function (compare) {
+  return function (leftOperand, rightOperand, caseInsensitive) {
+    leftOperand = castToStringIfNumber(leftOperand);
+    rightOperand = castToStringIfNumber(rightOperand);
+
+    return (
+      isString(leftOperand) &&
+      isString(rightOperand) &&
+      compare(leftOperand, rightOperand, caseInsensitive)
+    );
+  };
+};
+
+var guardNumberCompare = function (compare) {
+  return function (leftOperand, rightOperand) {
+    leftOperand = castToNumberIfString(leftOperand);
+    rightOperand = castToNumberIfString(rightOperand);
+
+    return (
+      isNumber(leftOperand) &&
+      isNumber(rightOperand) &&
+      compare(leftOperand, rightOperand)
+    );
+  };
+};
+
+var guardCaseSensitivity = function (compare) {
+  return function (leftOperand, rightOperand, caseInsensitive) {
+    return compare(
+      updateCase(leftOperand, caseInsensitive),
+      updateCase(rightOperand, caseInsensitive)
+    );
+  };
+};
+
+var conditions = {
+  equals: guardCaseSensitivity(function (leftOperand, rightOperand) {
+    return leftOperand == rightOperand;
+  }),
+  doesNotEqual: function () {
+    return !conditions.equals.apply(null, arguments);
+  },
+  contains: guardStringCompare(
+    guardCaseSensitivity(function (leftOperand, rightOperand) {
+      return leftOperand.indexOf(rightOperand) !== -1;
+    })
+  ),
+  doesNotContain: function () {
+    return !conditions.contains.apply(null, arguments);
+  },
+  startsWith: guardStringCompare(
+    guardCaseSensitivity(function (leftOperand, rightOperand) {
+      return leftOperand.indexOf(rightOperand) === 0;
+    })
+  ),
+  doesNotStartWith: function () {
+    return !conditions.startsWith.apply(null, arguments);
+  },
+  endsWith: guardStringCompare(
+    guardCaseSensitivity(function (leftOperand, rightOperand) {
+      return (
+        leftOperand.substring(
+          leftOperand.length - rightOperand.length,
+          leftOperand.length
+        ) === rightOperand
+      );
+    })
+  ),
+  doesNotEndWith: function () {
+    return !conditions.endsWith.apply(null, arguments);
+  },
+  matchesRegex: guardStringCompare(function (
+    leftOperand,
+    rightOperand,
+    caseInsensitive
+  ) {
+    // Doing something like new RegExp(/ab+c/, 'i') throws an error in some browsers (e.g., IE11),
+    // so we don't want to instantiate the regex until we know we're working with a string.
+    return new RegExp(rightOperand, caseInsensitive ? 'i' : '').test(
+      leftOperand
+    );
+  }),
+  doesNotMatchRegex: function () {
+    return !conditions.matchesRegex.apply(null, arguments);
+  },
+  lessThan: guardNumberCompare(function (leftOperand, rightOperand) {
+    return leftOperand < rightOperand;
+  }),
+  lessThanOrEqual: guardNumberCompare(function (leftOperand, rightOperand) {
+    return leftOperand <= rightOperand;
+  }),
+  greaterThan: guardNumberCompare(function (leftOperand, rightOperand) {
+    return leftOperand > rightOperand;
+  }),
+  greaterThanOrEqual: guardNumberCompare(function (leftOperand, rightOperand) {
+    return leftOperand >= rightOperand;
+  }),
+  isTrue: function (leftOperand) {
+    return leftOperand === true;
+  },
+  isTruthy: function (leftOperand) {
+    return Boolean(leftOperand);
+  },
+  isFalse: function (leftOperand) {
+    return leftOperand === false;
+  },
+  isFalsy: function (leftOperand) {
+    return !leftOperand;
+  }
+};
+
+module.exports = function (settings) {
+  return (conditions[settings.comparison.operator](
+    settings.leftOperand,
+    settings.rightOperand,
+    Boolean(settings.comparison.caseInsensitive)
+  ))?settings.conditionalValue:settings.fallbackValue;
+};

--- a/src/lib/dataElements/javascriptTools.js
+++ b/src/lib/dataElements/javascriptTools.js
@@ -1,0 +1,46 @@
+/***************************************************************************************
+ * (c) 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+/**
+ * The launch environment data element.
+ * @param {Object} settings The data element settings object.
+ * @param {string} settings.operator The attribute that contains the desired operation.
+ * @returns {string}
+ */
+module.exports = function (settings) {
+      switch (settings.operator) {
+        case 'substring':
+          return settings.sourceValue.substring((settings.stringStart!=''?settings.stringStart:undefined),(settings.stringEnd!=''?settings.stringEnd:undefined));
+        case 'join':
+          return settings.sourceValue.join(settings.delimiter);
+        case 'split':
+          return settings.sourceValue.split(settings.delimiter);
+        case 'regexReplace':
+          var re = new RegExp(settings.regexInput, (settings.caseInsensitive?"i":"")+(settings.replaceAll?"g":""));
+          return (settings.replaceAll?settings.sourceValue.replaceAll(re, settings.replacement):settings.sourceValue.replace(re, settings.replacement));
+        case 'simpleReplace':
+          return (settings.replaceAll?settings.sourceValue.replaceAll(settings.search, settings.replacement):settings.sourceValue.replace(settings.search, settings.replacement));
+        case 'regexMatch':
+          var re = new RegExp(settings.regexInput, (settings.caseInsensitive?"i":""));
+          return settings.sourceValue.match(re)[1];
+        case 'eval':
+          return eval(settings.sourceCode);
+        case 'capitalizeValue':
+          return settings.sourceValue.charAt(0).toUpperCase() + settings.sourceValue.slice(1);;
+        case 'uppercaseValue':
+          return settings.sourceValue.toUpperCase();
+        case 'lowercaseValue':
+          return settings.sourceValue.toLowerCase();
+      }
+};

--- a/src/lib/dataElements/javascriptTools.js
+++ b/src/lib/dataElements/javascriptTools.js
@@ -18,7 +18,7 @@
  * @param {string} settings.operator The attribute that contains the desired operation.
  * @returns {string}
  */
-module.exports = function (settings) {
+module.exports = function (settings,event) {
       switch (settings.operator) {
         case 'substring':
           return settings.sourceValue.substring((settings.stringStart!=''?settings.stringStart:undefined),(settings.stringEnd!=''?settings.stringEnd:undefined));
@@ -34,13 +34,23 @@ module.exports = function (settings) {
         case 'regexMatch':
           var re = new RegExp(settings.regexInput, (settings.caseInsensitive?"i":""));
           return settings.sourceValue.match(re)[1];
-        case 'eval':
-          return eval(settings.sourceCode);
         case 'capitalizeValue':
           return settings.sourceValue.charAt(0).toUpperCase() + settings.sourceValue.slice(1);;
         case 'uppercaseValue':
           return settings.sourceValue.toUpperCase();
         case 'lowercaseValue':
           return settings.sourceValue.toLowerCase();
+        case 'length':
+          return settings.sourceValue.length;
+        case 'indexOf':
+          return settings.sourceValue.indexOf(settings.search);
+        case 'lastIndexOf':
+          return settings.sourceValue.lastIndexOf(settings.search);
+        case 'arrayPop':
+          return settings.sourceValue.pop();
+        case 'arrayShift':
+          return settings.sourceValue.shift();
+        case 'slice':
+          return settings.sourceValue.slice((settings.stringStart!=''?settings.stringStart:undefined),(settings.stringEnd!=''?settings.stringEnd:undefined));
       }
 };

--- a/src/lib/dataElements/launchEnvironment.js
+++ b/src/lib/dataElements/launchEnvironment.js
@@ -18,7 +18,7 @@
  * @param {string} settings.attribute The attribute that should be returned.
  * @returns {string}
  */
-module.exports = function (settings) {
+module.exports = function (settings,event) {
       switch (settings.attribute) {
         case 'buildDate':
           return turbine.buildInfo.buildDate;
@@ -26,5 +26,15 @@ module.exports = function (settings) {
           return turbine.buildInfo.environment;
         case 'property':
           return _satellite.property.name;
+        case 'ruleName':
+          return event.$rule.name;
+        case 'ruleId':
+          return event.$rule.id;
+        case 'eventType':
+          return event.$type;
+        case 'eventDetail':
+          return event.detail;
+        case 'DCRIdentifier':
+          return event.identifier;
       }
 };

--- a/src/lib/dataElements/launchEnvironment.js
+++ b/src/lib/dataElements/launchEnvironment.js
@@ -1,0 +1,30 @@
+/***************************************************************************************
+ * (c) 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+/**
+ * The launch environment data element.
+ * @param {Object} settings The data element settings object.
+ * @param {string} settings.attribute The attribute that should be returned.
+ * @returns {string}
+ */
+module.exports = function (settings) {
+      switch (settings.attribute) {
+        case 'buildDate':
+          return turbine.buildInfo.buildDate;
+        case 'environment':
+          return turbine.buildInfo.environment;
+        case 'property':
+          return _satellite.property.name;
+      }
+};

--- a/src/lib/dataElements/visitorAttributes.js
+++ b/src/lib/dataElements/visitorAttributes.js
@@ -1,0 +1,35 @@
+/***************************************************************************************
+ * (c) 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+const clientInfo = require('../conditions/helpers/clientInfo');
+
+/**
+ * The visitor attributes data element.
+ * @param {Object} settings The data element settings object.
+ * @param {string} settings.attribute The attribute that should be returned.
+ * @returns {string}
+ */
+module.exports = function (settings) {
+      switch (settings.attribute) {
+        case 'browser':
+          return clientInfo.browser;
+        case 'operatingSystem':
+          return clientInfo.os;
+        case 'deviceType':
+          return clientInfo.deviceType;
+        case 'windowSize':
+          return document.documentElement.clientWidth + "x" + document.documentElement.clientHeight;
+        case 'screenSize':
+          return window.screen.width + "x" + window.screen.height;
+      }
+};

--- a/src/view/dataElements/conditionalValue.jsx
+++ b/src/view/dataElements/conditionalValue.jsx
@@ -1,0 +1,361 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+ import React from 'react';
+ import { connect } from 'react-redux';
+ import { TextField, Checkbox, Picker, Item, Flex } from '@adobe/react-spectrum';
+ import { formValueSelector } from 'redux-form';
+ import RegexTestButton from '../components/regexTestButton';
+ import WrappedField from '../components/wrappedField';
+ import HelpText from '../components/helpText';
+ import NoWrapText from '../components/noWrapText';
+ import { isDataElementToken, isNumberLike } from '../utils/validators';
+ 
+ const operators = {
+   EQUALS: 'equals',
+   DOES_NOT_EQUAL: 'doesNotEqual',
+   CONTAINS: 'contains',
+   DOES_NOT_CONTAIN: 'doesNotContain',
+   STARTS_WITH: 'startsWith',
+   DOES_NOT_START_WITH: 'doesNotStartWith',
+   ENDS_WITH: 'endsWith',
+   DOES_NOT_END_WITH: 'doesNotEndWith',
+   MATCHES_REGEX: 'matchesRegex',
+   DOES_NOT_MATCH_REGEX: 'doesNotMatchRegex',
+   LESS_THAN: 'lessThan',
+   LESS_THAN_OR_EQUAL: 'lessThanOrEqual',
+   GREATER_THAN: 'greaterThan',
+   GREATER_THAN_OR_EQUAL: 'greaterThanOrEqual',
+   IS_TRUE: 'isTrue',
+   IS_TRUTHY: 'isTruthy',
+   IS_FALSE: 'isFalse',
+   IS_FALSY: 'isFalsy'
+ };
+ 
+ const metaByOperator = {
+   [operators.EQUALS]: {
+     // We don't have isRightOperandLengthRequired set to true for the equals operator because
+     // creating a comparison to determine if a value equals an empty string is a legit
+     // use case.
+     label: 'Equals',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     saveOperandAsNumberWhenPossible: true
+   },
+   [operators.DOES_NOT_EQUAL]: {
+     // We don't have isRightOperandLengthRequired set to true for the doesNotEqual operator because
+     // We don't have isRightOperandLengthRequired set to true for the doesNotEqual operator because
+     // creating a comparison to determine if a value does not equal an empty string is a legit
+     // use case.
+     label: 'Does Not Equal',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     saveOperandAsNumberWhenPossible: true
+   },
+   [operators.CONTAINS]: {
+     label: 'Contains',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.DOES_NOT_CONTAIN]: {
+     label: 'Does Not Contain',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.STARTS_WITH]: {
+     label: 'Starts With',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.DOES_NOT_START_WITH]: {
+     label: 'Does Not Start With',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.ENDS_WITH]: {
+     label: 'Ends With',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.DOES_NOT_END_WITH]: {
+     label: 'Does Not End With',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.MATCHES_REGEX]: {
+     label: 'Matches Regex',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.DOES_NOT_MATCH_REGEX]: {
+     label: 'Does Not Match Regex',
+     supportsCaseSensitivity: true,
+     supportsRightOperand: true,
+     rightOperandMustBeNonEmptyString: true
+   },
+   [operators.LESS_THAN]: {
+     label: 'Is Less Than',
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     saveOperandAsNumberWhenPossible: true,
+     rightOperandMustBeNumberOrDataElement: true
+   },
+   [operators.LESS_THAN_OR_EQUAL]: {
+     label: 'Is Less Than Or Equal To',
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     saveOperandAsNumberWhenPossible: true,
+     rightOperandMustBeNumberOrDataElement: true
+   },
+   [operators.GREATER_THAN]: {
+     label: 'Is Greater Than',
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     saveOperandAsNumberWhenPossible: true,
+     rightOperandMustBeNumberOrDataElement: true
+   },
+   [operators.GREATER_THAN_OR_EQUAL]: {
+     label: 'Is Greater Than Or Equal To',
+     supportsRightOperand: true,
+     rigthOperandIsRequired: true,
+     saveOperandAsNumberWhenPossible: true,
+     rightOperandMustBeNumberOrDataElement: true
+   },
+   [operators.IS_TRUE]: {
+     label: 'Is True'
+   },
+   [operators.IS_TRUTHY]: {
+     label: 'Is Truthy'
+   },
+   [operators.IS_FALSE]: {
+     label: 'Is False'
+   },
+   [operators.IS_FALSY]: {
+     label: 'Is Falsy'
+   }
+ };
+ 
+ const operatorOptions = Object.keys(metaByOperator).map((operator) => ({
+   id: operator,
+   name: metaByOperator[operator].label
+ }));
+ 
+ const NoTypeConversionReminder = ({ operator, value }) => {
+   const sketchyStrings = ['true', 'false', 'null', 'undefined'];
+ 
+   return (operator === operators.EQUALS ||
+     operator === operators.DOES_NOT_EQUAL) &&
+     sketchyStrings.indexOf(value.toLowerCase()) !== -1 ? (
+     <HelpText>
+       Be aware that the value &quot;
+       {value}
+       &quot; will be compared as a string.
+     </HelpText>
+   ) : null;
+ };
+ 
+ const RightOperandFields = ({ operator, caseInsensitive, rightOperand }) => {
+   if (metaByOperator[operator].supportsRightOperand) {
+     return operator === operators.MATCHES_REGEX ||
+       operator === operators.DOES_NOT_MATCH_REGEX ? (
+       <Flex gap="size-100">
+         <WrappedField
+           label="Right Operand"
+           name="rightOperand"
+           component={TextField}
+           width="size-3000"
+           supportDataElement
+           isRequired
+         />
+         <WrappedField
+           name="rightOperand"
+           component={RegexTestButton}
+           flags={caseInsensitive ? 'i' : ''}
+         />
+       </Flex>
+     ) : (
+       <>
+         <WrappedField
+           label="Right Operand"
+           name="rightOperand"
+           width="size-3000"
+           component={TextField}
+           supportDataElement
+           isRequired={metaByOperator[operator].rigthOperandIsRequired}
+         />
+         <NoTypeConversionReminder operator={operator} value={rightOperand} />
+       </>
+     );
+   }
+   return null;
+ };
+
+ const ConditionalField = ({}) => {
+    return (    <>
+        <WrappedField
+          label="If true, return this string value"
+          name="conditionalValue"
+          placeholder="Value if true"
+          width="size-3000"
+          component={TextField}
+          supportDataElement
+          isRequired
+        />
+      </>);
+  };
+
+  const FallbackField = ({}) => {
+    return(
+        <>
+          <WrappedField
+            label="Otherwise, return this string value"
+            name="fallbackValue"
+            placeholder="Value if false"
+            width="size-3000"
+            component={TextField}
+            supportDataElement
+          />
+        </>);
+  };
+ 
+ const ValueComparison = ({ operator, ...rest }) => (
+   <Flex gap="size-100" direction="column">
+     <NoWrapText>Compare two values and return a value based on the result</NoWrapText>
+     <WrappedField
+       minWidth="size-3000"
+       label="Left Operand"
+       name="leftOperand"
+       component={TextField}
+       isRequired
+       supportDataElement
+     />
+     <Flex gap="size-100">
+       <WrappedField
+         width="size-3000"
+         name="operator"
+         label="Operator"
+         component={Picker}
+         items={operatorOptions}
+       >
+         {(item) => <Item>{item.name}</Item>}
+       </WrappedField>
+       {metaByOperator[operator].supportsCaseSensitivity ? (
+         <WrappedField
+           minWidth="size-2000"
+           name="caseInsensitive"
+           component={Checkbox}
+         >
+           Case Insensitive
+         </WrappedField>
+       ) : null}
+     </Flex>
+     <RightOperandFields operator={operator} {...rest} />
+     <ConditionalField />
+     <FallbackField />
+   </Flex>
+ );
+ 
+ const valueSelector = formValueSelector('default');
+ const stateToProps = (state) =>
+   valueSelector(
+     state,
+     'operator',
+     'caseInsensitive',
+     'leftOperand',
+     'rightOperand'
+   );
+ 
+ export default connect(stateToProps)(ValueComparison);
+ 
+ export const formConfig = {
+   settingsToFormValues(values, settings) {
+     return {
+       ...values,
+       leftOperand: settings.leftOperand || '',
+       conditionalValue: settings.conditionalValue || '',
+       fallbackValue: settings.fallbackValue || '',
+       operator:
+         (settings.comparison && settings.comparison.operator) ||
+         operators.EQUALS,
+       caseInsensitive: Boolean(
+         settings.comparison && settings.comparison.caseInsensitive
+       ),
+       rightOperand:
+         settings.rightOperand !== undefined ? String(settings.rightOperand) : ''
+     };
+   },
+   formValuesToSettings(settings, values) {
+     settings = {
+       ...settings,
+       leftOperand: values.leftOperand,
+       conditionalValue: values.conditionalValue,
+       fallbackValue: values.fallbackValue,
+       comparison: {
+         operator: values.operator
+       }
+     };
+     const operatorMeta = metaByOperator[values.operator];
+     if (operatorMeta.supportsCaseSensitivity && values.caseInsensitive) {
+       settings.comparison.caseInsensitive = values.caseInsensitive;
+     }
+     if (operatorMeta.supportsRightOperand) {
+       settings.rightOperand =
+         operatorMeta.saveOperandAsNumberWhenPossible &&
+         isNumberLike(values.rightOperand)
+           ? Number(values.rightOperand)
+           : String(values.rightOperand);
+     }
+     return settings;
+   },
+   validate(errors, values) {
+     errors = {
+       ...errors
+     };
+     if (!isDataElementToken(values.leftOperand)) {
+       errors.leftOperand = 'Please specify a data element';
+     }
+     if (!values.conditionalValue) {
+        errors.conditionalValue = 'Please specify a value or data element';
+      }
+     if (values.operator) {
+       const operatorMeta = metaByOperator[values.operator];
+       if (
+         operatorMeta.rightOperandMustBeNonEmptyString &&
+         !values.rightOperand
+       ) {
+         errors.rightOperand = 'Please specify a value';
+       }
+       if (
+         operatorMeta.rightOperandMustBeNumberOrDataElement &&
+         !isNumberLike(values.rightOperand) &&
+         !isDataElementToken(values.rightOperand)
+       ) {
+         errors.rightOperand = 'Please specify a number or data element';
+       }
+     }
+     return errors;
+   }
+ };
+ 

--- a/src/view/dataElements/javascriptTools.jsx
+++ b/src/view/dataElements/javascriptTools.jsx
@@ -1,0 +1,362 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+ import React from 'react';
+ import { connect } from 'react-redux';
+ import { TextField, Checkbox, Picker, Item, Flex } from '@adobe/react-spectrum';
+ import { formValueSelector } from 'redux-form';
+ import RegexTestButton from '../components/regexTestButton';
+ import WrappedField from '../components/wrappedField';
+ import NoWrapText from '../components/noWrapText';
+ import EditorButton from '../components/editorButton';
+ import { isDataElementToken, isNumberLike } from '../utils/validators';
+ 
+ const operators = {
+  CAPITALIZE_VALUE: 'capitalizeValue',
+  UPPERCASE_VALUE: 'uppercaseValue',
+  LOWERCASE_VALUE: 'lowercaseValue',
+  SUBSTRING: 'substring',
+  JOIN: 'join',
+  SPLIT: 'split',
+  REGEX_REPLACE: 'regexReplace',
+  SIMPLE_REPLACE: 'simpleReplace',
+  REGEX_MATCH: 'regexMatch',
+  EVAL: "eval"
+ };
+ 
+ const metaByOperator = {
+  [operators.CAPITALIZE_VALUE]: {
+    label: 'Capitalize Value'
+  },
+  [operators.UPPERCASE_VALUE]: {
+    label: 'Uppercase Value'
+  },
+  [operators.LOWERCASE_VALUE]: {
+    label: 'Lowercase Value'
+  },
+  [operators.SIMPLE_REPLACE]: {
+    label: 'Simple Replace',
+    requiresSearchValue: true,
+    supportsReplacement: true
+  },
+  [operators.REGEX_REPLACE]: {
+    label: 'Regex Replace',
+    requiresRegex: true,
+    supportsReplacement: true
+  },
+  [operators.SUBSTRING]: {
+     label: 'Substring',
+     requiresMin: true,
+     requiresMax: true
+   },
+   [operators.JOIN]: {
+     label: 'Join Array',
+     requiresDelimiter: true
+   },
+   [operators.SPLIT]: {
+     label: 'Split to Array',
+     requiresDelimiter: true
+   },
+   [operators.REGEX_MATCH]: {
+     label: 'Extract Value with Regex',
+     requiresRegex: true
+   },
+   [operators.EVAL]: {
+     label: 'Eval',
+     requiresCode: true
+   }
+ };
+ 
+ const operatorOptions = Object.keys(metaByOperator).map((operator) => ({
+   id: operator,
+   name: metaByOperator[operator].label
+ }));
+ 
+ const RegexFields = ({ operator, caseInsensitive }) => {
+   if (metaByOperator[operator].requiresRegex) {
+     return (<>
+       <Flex gap="size-100">
+         <WrappedField
+           label="Regex Expression"
+           name="regexInput"
+           component={TextField}
+           width="size-3000"
+           isRequired
+         />
+        <WrappedField
+          minWidth="size-2000"
+          name="caseInsensitive"
+          component={Checkbox}
+        >
+          Case Insensitive
+        </WrappedField>
+        <WrappedField
+           name="regexInput"
+           component={RegexTestButton}
+           flags={caseInsensitive ? 'i' : ''}
+         />
+       </Flex>
+    </>)
+   }
+   return null;
+ };
+ 
+ const OtherFields = ({ operator }) => {
+  if (metaByOperator[operator].requiresDelimiter) {
+   return (<>
+       <WrappedField
+         label="Value Separator"
+         name="delimiter"
+         component={TextField}
+         width="size-1000"
+         isRequired
+       />
+  </>)
+ }
+ if (metaByOperator[operator].supportsReplacement && !metaByOperator[operator].requiresSearchValue) {
+   return (<>
+   <Flex gap="size-100">
+       <WrappedField
+         label="Replacement Value"
+         name="replacement"
+         component={TextField}
+         width="size-3000"
+         supportDataElement
+       />
+        <WrappedField
+          minWidth="size-2000"
+          name="replaceAll"
+          component={Checkbox}
+        >
+          Replace all
+        </WrappedField>
+  </Flex>
+  </>)
+ }
+ if (metaByOperator[operator].supportsReplacement && metaByOperator[operator].requiresSearchValue) {
+  return (<>
+     <WrappedField
+        label="Search Value"
+        name="search"
+        component={TextField}
+        width="size-3000"
+        supportDataElement
+      />
+    <Flex gap="size-100">
+      <WrappedField
+        label="Replacement Value"
+        name="replacement"
+        component={TextField}
+        width="size-3000"
+        supportDataElement
+      />
+        <WrappedField
+          minWidth="size-2000"
+          name="replaceAll"
+          component={Checkbox}
+        >
+          Replace all
+        </WrappedField>
+      </Flex>
+ </>)
+}
+ if (metaByOperator[operator].requiresMax) {
+  return (<>
+  <Flex gap="size-100">
+      <WrappedField
+        label="Start Position"
+        name="stringStart"
+        component={TextField}
+        width="size-1000"
+      />
+      <WrappedField
+        label="End Position"
+        name="stringEnd"
+        component={TextField}
+        width="size-1000"
+      />
+  </Flex>
+ </>)
+}
+
+  return null;
+};
+
+ const JSTools = ({ operator, ...rest }) => {
+  if (metaByOperator[operator].requiresCode) {
+    return (<>
+    <NoWrapText>Apply simple JavaScript Operations</NoWrapText>
+      <Flex gap="size-100">
+       <WrappedField
+         width="size-3000"
+         name="operator"
+         label="Function"
+         component={Picker}
+         items={operatorOptions}
+       >
+         {(item) => <Item>{item.name}</Item>}
+       </WrappedField>
+       <WrappedField name="sourceCode" component={EditorButton} />
+     </Flex>
+   </>)
+  }
+  else{
+    return(
+   <Flex gap="size-100" direction="column">
+    <NoWrapText>Apply simple JavaScript Operations</NoWrapText>
+    <WrappedField
+         width="size-3000"
+         name="operator"
+         label="Function"
+         component={Picker}
+         items={operatorOptions}
+       >
+         {(item) => <Item>{item.name}</Item>}
+       </WrappedField>
+     <WrappedField
+       minWidth="size-3000"
+       label="Source Value"
+       name="sourceValue"
+       component={TextField}
+       isRequired
+       supportDataElement
+     /> 
+     <RegexFields operator={operator} {...rest} />
+     <OtherFields operator={operator} {...rest} />
+   </Flex>)
+  }
+ };
+ 
+ const valueSelector = formValueSelector('default');
+ const stateToProps = (state) =>
+   valueSelector(
+     state,
+     'operator',
+     'caseInsensitive'
+   );
+ 
+ export default connect(stateToProps)(JSTools);
+ 
+ export const formConfig = {
+   settingsToFormValues(values, settings) {
+     return {
+       ...values,
+       sourceValue: settings.sourceValue || '',
+       regexInput: settings.regexInput || '',
+       search: settings.search || '',
+       operator: settings.operator || 'capitalizeValue',
+       stringStart: settings.stringStart || '',
+       stringEnd: settings.stringEnd || '',
+       replacement: settings.replacement || '',
+       delimiter: settings.delimiter || '',
+       caseInsensitive: settings.caseInsensitive || '',
+       sourceCode: settings.sourceCode || '',
+       replaceAll: settings.replaceAll || '',
+     };
+   },
+   formValuesToSettings(settings, values) {
+     settings = {
+       ...settings,
+       sourceValue: values.sourceValue,
+       operator: values.operator
+     };
+ 
+     const operatorMeta = metaByOperator[values.operator];
+ 
+     if (operatorMeta.requiresRegex && values.caseInsensitive) {
+       settings.caseInsensitive = values.caseInsensitive;
+     }
+ 
+     if (operatorMeta.requiresRegex) {
+      settings.regexInput = values.regexInput;
+    }
+
+     if (operatorMeta.requiresDelimiter) {
+       settings.delimiter = values.delimiter;
+     }
+
+     if (operatorMeta.supportsReplacement) {
+      settings.replacement = values.replacement;
+      settings.replaceAll = values.replaceAll;
+    }
+
+    if (operatorMeta.requiresSearchValue) {
+      settings.search = values.search;
+    }
+
+    if (operatorMeta.requiresCode) {
+      settings.sourceCode = values.sourceCode;
+    }
+
+    if (operatorMeta.requiresMin && operatorMeta.requiresMax) {
+      settings.stringStart = values.stringStart;
+      settings.stringEnd = values.stringEnd;
+    }
+ 
+     return settings;
+   },
+   validate(errors, values) {
+     errors = {
+       ...errors
+     };
+ 
+     if (!isDataElementToken(values.sourceValue)) {
+       errors.sourceValue = 'Please specify a data element';
+     }
+ 
+     if (values.operator) {
+       const operatorMeta = metaByOperator[values.operator];
+ 
+       if (
+         operatorMeta.requiresRegex &&
+         !values.regexInput
+       ) {
+         errors.regexInput = 'Please specify a regex expression';
+       }
+
+       if (
+        operatorMeta.requiresDelimiter &&
+        !values.delimiter
+      ) {
+        errors.delimiter = 'Please specify a delimiter';
+      }
+
+      if (
+        operatorMeta.requiresSearchValue &&
+        !values.search
+      ) {
+        errors.search = 'Please specify a value to search for';
+      }
+
+      if (
+        operatorMeta.requiresCode &&
+        (!values.sourceCode || values.sourceCode.length>500)
+      ) {
+        errors.sourceCode = 'Please specify a script no longer than 500 characters';
+      }
+ 
+       if (
+         operatorMeta.requiresMin && operatorMeta.requiresMax
+       ) {
+        if (values.stringStart && !isNumberLike(values.stringStart)) {
+          errors.stringStart = 'Please specify a number';
+        }
+        if (values.stringEnd && !isNumberLike(values.stringEnd)) {
+          errors.stringEnd = 'Please specify a number';
+        }
+       }
+     }
+ 
+     return errors;
+   }
+ };
+ 

--- a/src/view/dataElements/javascriptTools.jsx
+++ b/src/view/dataElements/javascriptTools.jsx
@@ -17,7 +17,6 @@
  import RegexTestButton from '../components/regexTestButton';
  import WrappedField from '../components/wrappedField';
  import NoWrapText from '../components/noWrapText';
- import EditorButton from '../components/editorButton';
  import { isDataElementToken, isNumberLike } from '../utils/validators';
  
  const operators = {
@@ -25,12 +24,17 @@
   UPPERCASE_VALUE: 'uppercaseValue',
   LOWERCASE_VALUE: 'lowercaseValue',
   SUBSTRING: 'substring',
-  JOIN: 'join',
-  SPLIT: 'split',
   REGEX_REPLACE: 'regexReplace',
   SIMPLE_REPLACE: 'simpleReplace',
   REGEX_MATCH: 'regexMatch',
-  EVAL: "eval"
+  LENGTH: 'length',
+  INDEX_OF: 'indexOf',
+  LAST_INDEX_OF: 'lastIndexOf',
+  JOIN: 'join',
+  SPLIT: 'split',
+  ARRAY_POP: 'arrayPop',
+  ARRAY_SHIFT: 'arrayShift',
+  SLICE: 'slice'
  };
  
  const metaByOperator = {
@@ -58,21 +62,39 @@
      requiresMin: true,
      requiresMax: true
    },
-   [operators.JOIN]: {
-     label: 'Join Array',
-     requiresDelimiter: true
-   },
-   [operators.SPLIT]: {
-     label: 'Split to Array',
-     requiresDelimiter: true
-   },
    [operators.REGEX_MATCH]: {
      label: 'Extract Value with Regex',
      requiresRegex: true
    },
-   [operators.EVAL]: {
-     label: 'Eval',
-     requiresCode: true
+   [operators.LENGTH]: {
+     label: 'Length of String or Array'
+   },
+   [operators.INDEX_OF]: {
+     label: 'First index of character in string',
+     requiresSearchValue: true
+   },
+   [operators.LAST_INDEX_OF]: {
+     label: 'Last index of character in string',
+     requiresSearchValue: true
+   },
+   [operators.JOIN]: {
+    label: 'Join Array',
+    requiresDelimiter: true
+  },
+  [operators.SPLIT]: {
+    label: 'Split to Array',
+    requiresDelimiter: true
+  },
+   [operators.ARRAY_POP]: {
+     label: 'Array Pop'
+   },
+   [operators.ARRAY_SHIFT]: {
+     label: 'Array Shift'
+   },
+   [operators.SLICE]: {
+     label: 'Array or String Slice',
+     requiresMin: true,
+     requiresMax: true
    }
  };
  
@@ -169,6 +191,19 @@
       </Flex>
  </>)
 }
+if (metaByOperator[operator].requiresSearchValue) {
+  return (<>
+  <Flex gap="size-100">
+    <WrappedField
+        label="Search Value"
+        name="search"
+        component={TextField}
+        width="size-3000"
+        supportDataElement
+      />
+ </Flex>
+ </>)
+}
  if (metaByOperator[operator].requiresMax) {
   return (<>
   <Flex gap="size-100">
@@ -192,24 +227,6 @@
 };
 
  const JSTools = ({ operator, ...rest }) => {
-  if (metaByOperator[operator].requiresCode) {
-    return (<>
-    <NoWrapText>Apply simple JavaScript Operations</NoWrapText>
-      <Flex gap="size-100">
-       <WrappedField
-         width="size-3000"
-         name="operator"
-         label="Function"
-         component={Picker}
-         items={operatorOptions}
-       >
-         {(item) => <Item>{item.name}</Item>}
-       </WrappedField>
-       <WrappedField name="sourceCode" component={EditorButton} />
-     </Flex>
-   </>)
-  }
-  else{
     return(
    <Flex gap="size-100" direction="column">
     <NoWrapText>Apply simple JavaScript Operations</NoWrapText>
@@ -233,7 +250,7 @@
      <RegexFields operator={operator} {...rest} />
      <OtherFields operator={operator} {...rest} />
    </Flex>)
-  }
+  
  };
  
  const valueSelector = formValueSelector('default');
@@ -259,7 +276,6 @@
        replacement: settings.replacement || '',
        delimiter: settings.delimiter || '',
        caseInsensitive: settings.caseInsensitive || '',
-       sourceCode: settings.sourceCode || '',
        replaceAll: settings.replaceAll || '',
      };
    },
@@ -291,10 +307,6 @@
 
     if (operatorMeta.requiresSearchValue) {
       settings.search = values.search;
-    }
-
-    if (operatorMeta.requiresCode) {
-      settings.sourceCode = values.sourceCode;
     }
 
     if (operatorMeta.requiresMin && operatorMeta.requiresMax) {
@@ -336,24 +348,17 @@
       ) {
         errors.search = 'Please specify a value to search for';
       }
-
-      if (
-        operatorMeta.requiresCode &&
-        (!values.sourceCode || values.sourceCode.length>500)
-      ) {
-        errors.sourceCode = 'Please specify a script no longer than 500 characters';
-      }
  
-       if (
-         operatorMeta.requiresMin && operatorMeta.requiresMax
-       ) {
-        if (values.stringStart && !isNumberLike(values.stringStart)) {
-          errors.stringStart = 'Please specify a number';
-        }
-        if (values.stringEnd && !isNumberLike(values.stringEnd)) {
-          errors.stringEnd = 'Please specify a number';
-        }
-       }
+      if (
+        operatorMeta.requiresMin && operatorMeta.requiresMax
+      ) {
+      if (values.stringStart && !isNumberLike(values.stringStart)) {
+        errors.stringStart = 'Please specify a number';
+      }
+      if (values.stringEnd && !isNumberLike(values.stringEnd)) {
+        errors.stringEnd = 'Please specify a number';
+      }
+      }
      }
  
      return errors;

--- a/src/view/dataElements/launchEnvironment.jsx
+++ b/src/view/dataElements/launchEnvironment.jsx
@@ -26,6 +26,26 @@ const options = [
   {
     id: 'property',
     name: 'Property Name'
+  },
+  {
+    id: 'ruleName',
+    name: 'Rule Name'
+  },
+  {
+    id: 'ruleId',
+    name: 'Rule Id'
+  },
+  {
+    id: 'eventType',
+    name: 'Event Type'
+  },
+  {
+    id: 'eventDetail',
+    name: 'Event Detail Payload'
+  },
+  {
+    id: 'DCRIdentifier',
+    name: 'Direct Call Rule Identifier'
   }
 ];
 

--- a/src/view/dataElements/launchEnvironment.jsx
+++ b/src/view/dataElements/launchEnvironment.jsx
@@ -1,0 +1,59 @@
+/***************************************************************************************
+ * (c) 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+import React from 'react';
+import { Picker, Item } from '@adobe/react-spectrum';
+import FullWidthField from '../components/fullWidthField';
+
+const options = [
+  {
+    id: 'environment',
+    name: 'Environment Stage'
+  },
+  {
+    id: 'buildDate',
+    name: 'Library Build Date'
+  },
+  {
+    id: 'property',
+    name: 'Property Name'
+  }
+];
+
+const LaunchEnvironment = () => (
+  <FullWidthField
+    label="Attribute"
+    name="attribute"
+    component={Picker}
+    items={options}
+    containerMinWidth="size-6000"
+  >
+    {(item) => <Item>{item.name}</Item>}
+  </FullWidthField>
+);
+
+export default LaunchEnvironment;
+
+export const formConfig = {
+  settingsToFormValues(values, settings) {
+    return {
+      ...values,
+      attribute: settings.attribute || 'buildDate'
+    };
+  },
+  formValuesToSettings(settings, values) {
+    return {
+      ...settings,
+      ...values
+    };
+  }
+};

--- a/src/view/dataElements/visitorAttributes.jsx
+++ b/src/view/dataElements/visitorAttributes.jsx
@@ -1,0 +1,67 @@
+/***************************************************************************************
+ * (c) 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+import React from 'react';
+import { Picker, Item } from '@adobe/react-spectrum';
+import FullWidthField from '../components/fullWidthField';
+
+const options = [
+  {
+    id: 'browser',
+    name: 'Browser Family'
+  },
+  {
+    id: 'windowSize',
+    name: 'Browser Window Size'
+  },
+  {
+    id: 'deviceType',
+    name: 'Device Type'
+  },
+  {
+    id: 'operatingSystem',
+    name: 'Operating System'
+  },
+  {
+    id: 'screenSize',
+    name: 'Screen Size'
+  }
+];
+
+const VisitorAttributes = () => (
+  <FullWidthField
+    label="Attribute"
+    name="attribute"
+    component={Picker}
+    items={options}
+    containerMinWidth="size-6000"
+  >
+    {(item) => <Item>{item.name}</Item>}
+  </FullWidthField>
+);
+
+export default VisitorAttributes;
+
+export const formConfig = {
+  settingsToFormValues(values, settings) {
+    return {
+      ...values,
+      attribute: settings.attribute || 'browser'
+    };
+  },
+  formValuesToSettings(settings, values) {
+    return {
+      ...settings,
+      ...values
+    };
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull requests adds four new Data Elements:
- Conditional Value: Basically a wrapper for the "Value Comparison" condition (code is basically a 1:1 copy), but can return one of two values based on the result of the comparison. Can thereby handle "If... Then... Else..." scenarios without the need for extra rules.
- Launch Environment: Contains 8 pieces of information about the Launch environment:
  - Environment Stage: Returns _satellite.buildInfo.environment to differentiate between dev/staging/prod environments
  - Library Build Date: Returns _satellite.buildInfo.buildDate to monitor library versions
  - Property Name: Returns _satellite.property.name to get the name of the Launch property
  - Rule Name: Returns event.$rule.name containing the name of the executed rule
  - Rule Id: Returns event.$rule.id containing the Id of the executed rule
  - Event Type: Returns event.$type containing the type of event that triggered the rule
  - Event Detail Payload: Returns event.detail containing the payload of a Custom Event or Direct Call Rule
  - Direct Call Rule Identifier: Returns event.identifier containing the identifier of a Direct Call Rule
- JavaScript Tools: Wrappers for 15 common JavaScript operations for:
  - Basic string manipulation (capitalize, uppercase, lowercase, replace, substring, regex match, first- and last index)
  - Basic array operations (split, join, pop, shift)
  - Basic universal operations (slice, length)
- Visitor Attributes: Almost 1:1 copy of the Visitor Attributes condition, providing information about the user:
  - Browser Family
  - Browser Window Size
  - Device Type
  - Operating System
  - Screen Size

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#51 

## Motivation and Context

As described in #51, this pull requests adds Data Elements that aim to reduce the need for Custom Code Data Elements to 
- retrieve information about the runtime environment
- retrieve information about the visitor, which is already available in conditions
- return values on a condition in "If... Then... Else..."-style
- return values that have been transformed using basic JS operations like substrings

In my current and every previous company, we need to maintain our own private extension to have the described functionality. I know that we are not alone with this, so I feel like that basic functionality should be included in the Core extension so that it can be maintained centrally. There is not a lot of actual "logic" in those Data Elements, they just help us to keep our Launch properties maintainable for non-developers by avoiding tons of custom code in Data Elements (or even conditions). If any of the functionality would find its way into the Core extension, we would be super happy.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/56084103/118355846-a1c6ed80-b572-11eb-9909-24c6c0867618.png)
![image](https://user-images.githubusercontent.com/56084103/118355858-af7c7300-b572-11eb-8a71-fe36e12f5ac2.png)
![image](https://user-images.githubusercontent.com/56084103/118355868-ba370800-b572-11eb-8638-2153e1fba933.png)
![image](https://user-images.githubusercontent.com/56084103/118355875-c4f19d00-b572-11eb-9bfb-b51883ab9807.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project. (I think? I'm on Windows, so I can't run the linter)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (Would be happy to help)
- [ ] All tests pass and I've made any necessary test changes. (Tests won't run on Windows, so couldn't go into this)
- [x] I have run the extension sandbox successfully.
