### PR TITLE
blackout-next(1) PDCL-6238: log warning when localStorage/sessionStorage unavailable

### DIFF
--- a/src/lib/helpers/__tests__/getNamespacedStorage.test.js
+++ b/src/lib/helpers/__tests__/getNamespacedStorage.test.js
@@ -63,6 +63,11 @@ describe('getNamespacedStorage', function () {
         });
 
         it('proper error handling if storage is disabled', function () {
+          mockTurbineVariable({
+            logger: {
+              warn: jasmine.createSpy()
+            }
+          });
           var mockWindow = createMockWindowUnavailableStorage();
 
           var getNamespacedStorage =
@@ -73,6 +78,7 @@ describe('getNamespacedStorage', function () {
           var storage = getNamespacedStorage(storageType, 'featurex');
 
           expect(storage.getItem('foo')).toBeNull();
+          expect(turbine.logger.warn).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -95,6 +101,11 @@ describe('getNamespacedStorage', function () {
         });
 
         it('proper error handling if storage is disabled', function () {
+          mockTurbineVariable({
+            logger: {
+              warn: jasmine.createSpy()
+            }
+          });
           var mockWindow = createMockWindowUnavailableStorage();
 
           var getNamespacedStorage =

--- a/src/lib/helpers/getNamespacedStorage.js
+++ b/src/lib/helpers/getNamespacedStorage.js
@@ -15,6 +15,8 @@ var window = require('@adobe/reactor-window');
 var BASE_NAMESPACE = 'com.adobe.reactor.core';
 
 module.exports = function (storageType, additionalNamespace) {
+  var STORAGE_TYPE_UNAVAILABLE_ERROR =
+    '"' + storageType + '" is not available on the window object.';
   var namespace = BASE_NAMESPACE + '.' + additionalNamespace;
 
   // When storage is disabled on Safari, the mere act of referencing window.localStorage
@@ -29,6 +31,7 @@ module.exports = function (storageType, additionalNamespace) {
       try {
         return window[storageType].getItem(namespace + '.' + name);
       } catch (e) {
+        turbine.logger.warn(STORAGE_TYPE_UNAVAILABLE_ERROR);
         return null;
       }
     },
@@ -43,6 +46,7 @@ module.exports = function (storageType, additionalNamespace) {
         window[storageType].setItem(namespace + '.' + name, value);
         return true;
       } catch (e) {
+        turbine.logger.warn(STORAGE_TYPE_UNAVAILABLE_ERROR);
         return false;
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Customer stated that storage api's being disabled lead to failures, but it looks null safe to me. Added some logging.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-6238

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] I have updated the Experience League documentation for the [Core Extension](https://git.corp.adobe.com/AdobeDocs/experience-platform.en/tree/master/help/tags/extensions/web/core)
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
