### PR TITLE
blackout-next(3) Pdcl 6233 support keyup keydown

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -611,11 +611,105 @@
       }
     },
     {
+      "name": "key-down",
+      "categoryName": "Keyboard",
+      "displayName": "Key Down",
+      "libPath": "src/lib/events/keyDown.js",
+      "viewPath": "events/keyDown.html",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "elementSelector": {
+            "type": "string",
+            "minLength": 1
+          },
+          "elementProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "value": {
+                  "type": "string"
+                },
+                "valueIsRegex": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["name", "value"]
+            }
+          },
+          "bubbleFireIfParent": {
+            "type": "boolean"
+          },
+          "bubbleFireIfChildFired": {
+            "type": "boolean"
+          },
+          "bubbleStop": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "key-press",
       "categoryName": "Keyboard",
       "displayName": "Key Press",
       "libPath": "src/lib/events/keyPress.js",
       "viewPath": "events/keyPress.html",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "elementSelector": {
+            "type": "string",
+            "minLength": 1
+          },
+          "elementProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "value": {
+                  "type": "string"
+                },
+                "valueIsRegex": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["name", "value"]
+            }
+          },
+          "bubbleFireIfParent": {
+            "type": "boolean"
+          },
+          "bubbleFireIfChildFired": {
+            "type": "boolean"
+          },
+          "bubbleStop": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "key-up",
+      "categoryName": "Keyboard",
+      "displayName": "Key Up",
+      "libPath": "src/lib/events/keyUp.js",
+      "viewPath": "events/keyUp.html",
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,11 +21,11 @@ if (process.env.CI) {
     ')';
 
   defaultBrowsers = [
-    // 'SL_EDGE',
+    'SL_EDGE',
     'SL_CHROME',
     // 'SL_FIREFOX',
     // 'SL_ANDROID', Nuking for now
-    // 'SL_SAFARI'
+    'SL_SAFARI'
   ];
   reporters.push('saucelabs');
 } else {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,11 +21,11 @@ if (process.env.CI) {
     ')';
 
   defaultBrowsers = [
-    'SL_EDGE',
+    // 'SL_EDGE',
     'SL_CHROME',
-    'SL_FIREFOX',
+    // 'SL_FIREFOX',
     // 'SL_ANDROID', Nuking for now
-    'SL_SAFARI'
+    // 'SL_SAFARI'
   ];
   reporters.push('saucelabs');
 } else {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "redux-form": "^8.3.7"
   },
   "devDependencies": {
-    "@adobe/reactor-sandbox": "^12.4.0",
+    "@adobe/reactor-sandbox": "^12.5.0-beta.0",
     "@babel/core": "^7.15.5",
     "@babel/eslint-parser": "^7.17.0",
     "@babel/plugin-proposal-class-properties": "^7.14.5",

--- a/src/lib/events/__tests__/keyDown.test.js
+++ b/src/lib/events/__tests__/keyDown.test.js
@@ -1,0 +1,22 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+describe('key press event delegate', function () {
+  var testStandardEvent = require('./helpers/testStandardEvent');
+  var delegate = require('../keyDown');
+
+  testStandardEvent(function () {
+    return delegate;
+  }, 'keydown');
+});

--- a/src/lib/events/__tests__/keyUp.test.js
+++ b/src/lib/events/__tests__/keyUp.test.js
@@ -1,0 +1,22 @@
+/***************************************************************************************
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+describe('key press event delegate', function () {
+  var testStandardEvent = require('./helpers/testStandardEvent');
+  var delegate = require('../keyUp');
+
+  testStandardEvent(function () {
+    return delegate;
+  }, 'keyup');
+});

--- a/src/lib/events/keyDown.js
+++ b/src/lib/events/keyDown.js
@@ -1,0 +1,39 @@
+/***************************************************************************************
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+var bubbly = require('./helpers/createBubbly')();
+
+document.addEventListener('keydown', bubbly.evaluateEvent, true);
+
+/**
+ * The keydown event. This event occurs when any key is depressed.
+ * @param {Object} settings The event settings object.
+ * @param {string} [settings.elementSelector] The CSS selector the element must match in order for
+ * the rule to fire.
+ * @param {Object[]} [settings.elementProperties] Property values the element must have in order
+ * for the rule to fire.
+ * @param {string} settings.elementProperties[].name The property name.
+ * @param {string} settings.elementProperties[].value The property value.
+ * @param {boolean} [settings.elementProperties[].valueIsRegex=false] Whether <code>value</code>
+ * on the object instance is intended to be a regular expression.
+ * @param {boolean} [settings.bubbleFireIfParent=true] Whether the rule should fire if
+ * the event originated from a descendant element.
+ * @param {boolean} [settings.bubbleFireIfChildFired=true] Whether the rule should fire
+ * if the same event has already triggered a rule targeting a descendant element.
+ * @param {boolean} [settings.bubbleStop=false] Whether the event should not trigger
+ * rules on ancestor elements.
+ * @param {ruleTrigger} trigger The trigger callback.
+ */
+module.exports = function (settings, trigger) {
+  bubbly.addListener(settings, trigger);
+};

--- a/src/lib/events/keyUp.js
+++ b/src/lib/events/keyUp.js
@@ -1,0 +1,39 @@
+/***************************************************************************************
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+var bubbly = require('./helpers/createBubbly')();
+
+document.addEventListener('keyup', bubbly.evaluateEvent, true);
+
+/**
+ * The keyup event. This event occurs when a key is released.
+ * @param {Object} settings The event settings object.
+ * @param {string} [settings.elementSelector] The CSS selector the element must match in order for
+ * the rule to fire.
+ * @param {Object[]} [settings.elementProperties] Property values the element must have in order
+ * for the rule to fire.
+ * @param {string} settings.elementProperties[].name The property name.
+ * @param {string} settings.elementProperties[].value The property value.
+ * @param {boolean} [settings.elementProperties[].valueIsRegex=false] Whether <code>value</code>
+ * on the object instance is intended to be a regular expression.
+ * @param {boolean} [settings.bubbleFireIfParent=true] Whether the rule should fire if
+ * the event originated from a descendant element.
+ * @param {boolean} [settings.bubbleFireIfChildFired=true] Whether the rule should fire
+ * if the same event has already triggered a rule targeting a descendant element.
+ * @param {boolean} [settings.bubbleStop=false] Whether the event should not trigger
+ * rules on ancestor elements.
+ * @param {ruleTrigger} trigger The trigger callback.
+ */
+module.exports = function (settings, trigger) {
+  bubbly.addListener(settings, trigger);
+};

--- a/src/view/events/keyDown.jsx
+++ b/src/view/events/keyDown.jsx
@@ -1,0 +1,21 @@
+/***************************************************************************************
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+import React from 'react';
+import StandardEvent, {
+  formConfig as standardEventFormConfig
+} from './components/standardEvent';
+
+export default () => (
+  <StandardEvent elementSpecificityLabel="When the user keys down on" />
+);
+export const formConfig = standardEventFormConfig;

--- a/src/view/events/keyUp.jsx
+++ b/src/view/events/keyUp.jsx
@@ -1,0 +1,21 @@
+/***************************************************************************************
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+import React from 'react';
+import StandardEvent, {
+  formConfig as standardEventFormConfig
+} from './components/standardEvent';
+
+export default () => (
+  <StandardEvent elementSpecificityLabel="When the user releases a key on" />
+);
+export const formConfig = standardEventFormConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,10 +129,10 @@
   dependencies:
     querystring "0.2.0"
 
-"@adobe/reactor-sandbox@^12.4.0":
-  version "12.4.0"
-  resolved "https://registry.yarnpkg.com/@adobe/reactor-sandbox/-/reactor-sandbox-12.4.0.tgz#3311e3ed24b26965320f9d4055209affe59f3c76"
-  integrity sha512-XdWpMtLiOZdjHqchdCr3FXibmLvfc8QtXT9eSBU9ZKf7ZmIT0XgR3AxsMWsPNxB/I6J7nDtJLUK4DElbEnQTlQ==
+"@adobe/reactor-sandbox@^12.5.0-beta.0":
+  version "12.5.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@adobe/reactor-sandbox/-/reactor-sandbox-12.5.0-beta.0.tgz#db7baae44a9e89d100d41703bd0aaa78b2710d2f"
+  integrity sha512-oSHAFp5nm7JLJtjFfFVg7UutUEpWoQgeeu8G3HfduIhVZ4XqvuGiHZ0OetgkiVNkDLbKlPLCM9o2yGUQo0M/zA==
   dependencies:
     "@adobe/react-spectrum" "^3.14.1"
     "@adobe/reactor-babel-plugin-replace-tokens-edge" "^1.1.0"
@@ -141,7 +141,7 @@
     "@adobe/reactor-token-scripts-edge" "^1.1.3"
     "@adobe/reactor-turbine" "^27.2.0"
     "@adobe/reactor-turbine-edge" "^2.1.0"
-    "@adobe/reactor-validator" "^2.2.0"
+    "@adobe/reactor-validator" "^2.3.0-beta.0"
     "@babel/core" "^7.15.8"
     "@babel/generator" "^7.15.8"
     "@babel/parser" "^7.15.8"
@@ -154,7 +154,7 @@
     "@rematch/core" "^2.1.1"
     "@spectrum-icons/illustrations" "^3.2.2"
     "@spectrum-icons/workflow" "^3.2.1"
-    ajv "^8.11.0"
+    ajv "^8.12.0"
     ajv-draft-04 "^1.0.0"
     ajv-formats "^2.1.1"
     body-parser "^1.19.0"
@@ -193,10 +193,10 @@
   resolved "https://registry.yarnpkg.com/@adobe/reactor-turbine-edge/-/reactor-turbine-edge-2.2.0.tgz#7bcce555c02c408ccb4237736efc567259dfc91f"
   integrity sha512-bARyjTblSA6GCP9yyCPonnOUwtyDK3c7tzCnhTh34jN3N5wvsO/xewbx6bjDVH53DpKtsC57AuDrJKv+Y4p3IQ==
 
-"@adobe/reactor-turbine-schemas@^10.3.0":
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-10.3.0.tgz#c45341c92b7f3793c3c269085976604d10073a29"
-  integrity sha512-iuaCgQAqL9ZpisBZHYM1fKlezLYFqPSL1MSDrvOgqH5LSuTlQXoDsvrg3blxjAuKXm8+PZBW03iaGn/WMH1ULA==
+"@adobe/reactor-turbine-schemas@^10.5.0-beta.0":
+  version "10.5.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-10.5.0-beta.0.tgz#fa775b357a24460bd8e11cb4adfa08dfe5222abc"
+  integrity sha512-3XSY0F9DdNXy088a57BdjUcqFll7MK8k0WNXfspQYrk2NxiUSLKrwqRYPKVNIhQNJu0XzvQ+unlDW3qi+VjwPg==
 
 "@adobe/reactor-turbine@^27.2.0":
   version "27.2.0"
@@ -212,13 +212,13 @@
     "@adobe/reactor-window" "*"
     is-plain-object "^2.0.4"
 
-"@adobe/reactor-validator@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@adobe/reactor-validator/-/reactor-validator-2.2.0.tgz#f6fd7d5d808526acc2dd46af53846c1c2b8bdf68"
-  integrity sha512-JNlCxZm4MfP3bJ8YcZEnTpIpduQ6moaiWOc3RPHrXxvJ3H/GEIfpPj7aVqKbvSo5v9vPlQbW31yGow4jDcbLfA==
+"@adobe/reactor-validator@^2.3.0-beta.0":
+  version "2.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@adobe/reactor-validator/-/reactor-validator-2.3.0-beta.0.tgz#76f1b668c7ccb44109c238a8fbd5c67c99b09c3d"
+  integrity sha512-t1KBKQhu02mGyNHW7UMXIDXI5g/gHxlTqChovujhMaLFje9yrWeu4OytOg1YwLTHRv7gSPvVkw//UHZftkUwOQ==
   dependencies:
-    "@adobe/reactor-turbine-schemas" "^10.3.0"
-    ajv "^8.11.0"
+    "@adobe/reactor-turbine-schemas" "^10.5.0-beta.0"
+    ajv "^8.12.0"
     ajv-draft-04 "^1.0.0"
     ajv-formats "^2.1.1"
 
@@ -3721,10 +3721,20 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.11.0:
+ajv@^8.0.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-6233

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Addresses #31 , which gives the user a way to hook into key events that aren't alphanumeric keys.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] I have updated the Experience League documentation for the [Core Extension](https://git.corp.adobe.com/AdobeDocs/experience-platform.en/tree/master/help/tags/extensions/web/core)
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
