### PR TITLE
blackout-next(4) Pdcl 6794 modern approach enters viewport

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 *.html
 *.css
 *.styl
+*.json

--- a/src/lib/events/entersViewport.js
+++ b/src/lib/events/entersViewport.js
@@ -15,20 +15,16 @@
 var document = require('@adobe/reactor-document');
 var window = require('@adobe/reactor-window');
 var WeakMap = require('./helpers/weakMap');
-var debounce = require('./helpers/debounce');
 var enableWeakMapDefaultValue = require('./helpers/enableWeakMapDefaultValue');
 var matchesSelector = require('./helpers/matchesSelector');
 var matchesProperties = require('./helpers/matchesProperties');
 var castToNumberIfString =
   require('../helpers/stringAndNumberUtils').castToNumberIfString;
 
-var POLL_INTERVAL = 3000;
-var DEBOUNCE_DELAY = 200;
 var frequencies = {
   FIRST_ENTRY: 'firstEntry',
   EVERY_ENTRY: 'everyEntry'
 };
-var isIE10 = window.navigator.appVersion.indexOf('MSIE 10') !== -1;
 
 var stateByElement = enableWeakMapDefaultValue(new WeakMap(), function () {
   return {
@@ -46,81 +42,12 @@ var stateByElement = enableWeakMapDefaultValue(new WeakMap(), function () {
   };
 });
 
-var listenersBySelector = {};
-
-/**
- * Gets the offset of the element.
- * @param elem
- * @returns {{top: number, left: number}}
- */
-var offset = function (elem) {
-  var box;
-
-  try {
-    box = elem.getBoundingClientRect();
-  } catch (e) {
-    // ignore
-  }
-
-  var docElem = document.documentElement;
-  var body = document.body;
-  var clientTop = docElem.clientTop || body.clientTop || 0;
-  var clientLeft = docElem.clientLeft || body.clientLeft || 0;
-  var scrollTop = window.pageYOffset || docElem.scrollTop || body.scrollTop;
-  var scrollLeft = window.pageXOffset || docElem.scrollLeft || body.scrollLeft;
-  var top = box.top + scrollTop - clientTop;
-  var left = box.left + scrollLeft - clientLeft;
-
-  return {
-    top: top,
-    left: left
-  };
-};
-
-/**
- * Viewport height.
- * @returns {number}
- */
-var getViewportHeight = function () {
-  var height = window.innerHeight; // Safari, Opera
-  var mode = document.compatMode;
-
-  if (mode) {
-    // IE, Gecko
-    height =
-      mode === 'CSS1Compat'
-        ? document.documentElement.clientHeight // Standards
-        : document.body.clientHeight; // Quirks
-  }
-
-  return height;
-};
-
-/**
- * Scroll top.
- * @returns {number}
- */
-var getScrollTop = function () {
-  return document.documentElement.scrollTop
-    ? document.documentElement.scrollTop
-    : document.body.scrollTop;
-};
-
-/**
- * Whether an element is in the viewport.
- * @param element The element to evaluate.
- * @param viewportHeight The viewport height. Passed in for optimization purposes.
- * @param scrollTop The scroll top. Passed in for optimization purposes.
- * @returns {boolean}
- */
-var elementIsInView = function (element, viewportHeight, scrollTop) {
-  var top = offset(element).top;
-  var height = element.offsetHeight;
-  return (
-    document.body.contains(element) &&
-    !(scrollTop > top + height || scrollTop + viewportHeight < top)
-  );
-};
+// trigger functions by elementSelector
+var listenersByDOMSelector = {};
+// IntersectionObservers by elementSelector
+var observersByDOMSelector = {};
+// elementSelectors that haven't been processed/found matching element on the page yet
+var observerQueue = [];
 
 /**
  * Handle when a targeted element is inside the viewport.
@@ -136,12 +63,12 @@ var handleElementInsideViewport = function (element) {
 
   // Evaluate the element against all stored listeners to see which ones should be triggered
   // due to the element being in the viewport.
-  Object.keys(listenersBySelector).forEach(function (selector) {
+  Object.keys(listenersByDOMSelector).forEach(function (selector) {
     if (!matchesSelector(element, selector)) {
       return;
     }
 
-    listenersBySelector[selector].forEach(function (listener) {
+    listenersByDOMSelector[selector].forEach(function (listener) {
       if (!matchesProperties(element, listener.settings.elementProperties)) {
         return;
       }
@@ -153,7 +80,6 @@ var handleElementInsideViewport = function (element) {
 
       var delayComplete = function () {
         var frequency = listener.settings.frequency || frequencies.FIRST_ENTRY;
-
         // When a user configures the event to only fire a rule once, then after the rule
         // has been triggered we store the "listener" in this array so that we know it's
         // been triggered and shouldn't be triggered in the future.
@@ -169,13 +95,12 @@ var handleElementInsideViewport = function (element) {
       };
 
       if (listener.settings.delay) {
-        var timeoutId = setTimeout(function () {
-          // One last check to make sure the element is still in view.
-          if (elementIsInView(element, getViewportHeight(), getScrollTop())) {
+        var timeoutId = window.setTimeout(function () {
+          // One last check to make sure the element is still in view, using fresh data
+          if (Boolean(stateByElement.get(element).inViewport)) {
             delayComplete();
           }
         }, listener.settings.delay);
-
         elementState.timeoutIds.push(timeoutId);
       } else {
         delayComplete();
@@ -190,7 +115,6 @@ var handleElementInsideViewport = function (element) {
 var handleElementOutsideViewport = function (element) {
   var elementState = stateByElement.get(element);
   elementState.inViewport = false;
-
   if (elementState.timeoutIds.length) {
     elementState.timeoutIds.forEach(clearTimeout);
     elementState.timeoutIds = [];
@@ -198,61 +122,139 @@ var handleElementOutsideViewport = function (element) {
 };
 
 /**
- * Checks to see if a rule's target selector matches an element in the viewport. If that element
- * has not been in the viewport prior, either (a) trigger the rule immediately if the user has not
- * elected to delay for a period of time or (b) start the delay period if the user has elected
- * to delay for a period of time. After an element being in the viewport triggers a rule, it
- * can't trigger the same rule again. If another element matching the same selector comes into
- * the viewport, it may trigger the same rule again.
+ * Ties observation of the elements to the selector used to find the elements.
+ *
+ * @param {string} elementSelector - The selector used to gather the elements on page.
+ * @param {HTMLElement[]} elements - The elements gathered by the selector.
  */
-var checkForElementsInViewport = debounce(function () {
-  var selectors = Object.keys(listenersBySelector);
+var observeElements = function (elementSelector, elements) {
+  var observer;
 
-  if (!selectors.length) {
+  // pull or create the IntersectionObserver for the elementSelector
+  if (observersByDOMSelector.hasOwnProperty(elementSelector)) {
+    observer = observersByDOMSelector[elementSelector];
+    // TODO what if elements go away for good? edge case to ignore?
+    //  worried that if we disconnect, we could miss a time to fire while
+    //  rebuilding the observer in here
+    // observer.disconnect();
+  } else {
+    var observerOptions = {
+      root: null,
+      rootMargin: '0px'
+    };
+    var observerCallback = function (observerEntries) {
+      observerEntries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          handleElementInsideViewport(entry.target);
+        } else {
+          handleElementOutsideViewport(entry.target);
+        }
+      });
+    };
+    observer = new IntersectionObserver(observerCallback, observerOptions);
+    observersByDOMSelector[elementSelector] = observer;
+  }
+
+  elements.forEach(function (element) {
+    observer.observe(element);
+  });
+};
+
+/**
+ * This is a fast queue of DOM element selectors where we pull all available
+ * elements and begin observing them.
+ *
+ * If we don't find any elements, we shove the DOM element back in the queue
+ * for the next tick.
+ */
+var initializeObserversInQueue = function () {
+  var observersToProcess = observerQueue;
+  observerQueue = [];
+  observersToProcess.forEach(function (elementSelector) {
+    var elements = document.querySelectorAll(elementSelector);
+    if (elements.length) {
+      observeElements(elementSelector, elements);
+    } else if (!observerQueue.includes(elementSelector)) {
+      observerQueue.push(elementSelector);
+    }
+  });
+};
+
+/**
+ * Slower queue that loops through all known Observer DOM selectors, and observes any
+ * newly found elements.
+ */
+var refreshObserverElements = function () {
+  Object.keys(observersByDOMSelector).forEach(function (elementSelector) {
+    observeElements(
+      elementSelector,
+      document.querySelectorAll(elementSelector)
+    );
+  });
+};
+
+var viewportIntervalIds = [];
+/**
+ * @param {Object} extensionModuleSettings
+ * @param {Number} extensionModuleSettings.observerProcessingFrequency
+ * @param {Number} extensionModuleSettings.observerElementRefreshFrequency
+ */
+var safelyBeginProcessing = function (extensionModuleSettings) {
+  // this check stops processing future calls immediately when the listeners are running
+  if (viewportIntervalIds.length) {
     return;
   }
 
-  // Find all the elements pertaining to rules using Enters Viewport.
-  var elements = document.querySelectorAll(selectors.join(','));
-
-  // Cached and re-used for optimization.
-  var viewportHeight = getViewportHeight();
-  var scrollTop = getScrollTop();
-
-  for (var i = 0; i < elements.length; i++) {
-    var element = elements[i];
-    if (elementIsInView(element, viewportHeight, scrollTop)) {
-      handleElementInsideViewport(element);
-    } else {
-      handleElementOutsideViewport(element);
+  var startObserverProcessingQueue = function (extensionModuleSettings) {
+    // this check prevents accidentally calling this multiple times before the DOM is ready
+    // and the check up-top wouldn't stop processing yet. By putting all this logic here,
+    // there doesn't need to be checking anywhere else.
+    if (!viewportIntervalIds.length) {
+      var observerProcessingFrequency = castToNumberIfString(
+        extensionModuleSettings.entersViewportObserverFrequency || 200
+      );
+      viewportIntervalIds.push(
+        window.setInterval(
+          initializeObserversInQueue,
+          observerProcessingFrequency
+        )
+      );
+      var observerElementRefreshFrequency = castToNumberIfString(
+        extensionModuleSettings.entersViewportElementRefreshFrequency || 3000
+      );
+      viewportIntervalIds.push(
+        window.setInterval(
+          refreshObserverElements,
+          observerElementRefreshFrequency
+        )
+      );
+      window.addEventListener(
+        'beforeunload',
+        function () {
+          viewportIntervalIds.forEach(function (intervalId) {
+            window.clearInterval(intervalId);
+          });
+          Object.keys(observersByDOMSelector).forEach(function (
+            elementSelector
+          ) {
+            // stops the observation of elements in the DOM
+            observersByDOMSelector[elementSelector].disconnect();
+          });
+        },
+        false
+      );
     }
-  }
-}, DEBOUNCE_DELAY);
+  };
 
-var initializeContentListeners = function () {
-  checkForElementsInViewport();
-  setInterval(checkForElementsInViewport, POLL_INTERVAL);
-  window.addEventListener('resize', checkForElementsInViewport);
-  window.addEventListener('scroll', checkForElementsInViewport);
-};
-
-// There's a bug in IE 10 where readyState is sometimes set to "interactive" too
-// early (before DOMContentLoaded has fired). To make sure the document is ready,
-// we'll wait until the window has loaded.
-// https://bugs.jquery.com/ticket/12282
-if (isIE10) {
-  if (document.readyState === 'complete') {
-    initializeContentListeners();
-  } else {
-    window.addEventListener('load', initializeContentListeners);
-  }
-} else {
   if (document.readyState !== 'loading') {
-    initializeContentListeners();
+    startObserverProcessingQueue(extensionModuleSettings);
   } else {
-    document.addEventListener('DOMContentLoaded', initializeContentListeners);
+    document.addEventListener(
+      'DOMContentLoaded',
+      startObserverProcessingQueue.bind(null, extensionModuleSettings)
+    );
   }
-}
+};
 
 /**
  * Enters viewport event. This event occurs when an element has entered the viewport. The rule
@@ -272,16 +274,26 @@ if (isIE10) {
  * within the viewport before declaring that the event has occurred.
  * @param {ruleTrigger} trigger The trigger callback.
  */
+var turbineExtensionSettings;
 module.exports = function (settings, trigger) {
-  var listeners = listenersBySelector[settings.elementSelector];
-
+  // first one in, turn on the lights. this pattern allows us to inject the
+  // Interval IDs using extension settings.
+  safelyBeginProcessing(
+    turbineExtensionSettings ||
+      (turbineExtensionSettings = turbine.getExtensionSettings())
+  );
+  // every listener should always be added to be notified
+  var listeners = listenersByDOMSelector[settings.elementSelector];
   if (!listeners) {
-    listeners = listenersBySelector[settings.elementSelector] = [];
+    listeners = listenersByDOMSelector[settings.elementSelector] = [];
   }
-
   settings.delay = castToNumberIfString(settings.delay);
   listeners.push({
     settings: settings,
     trigger: trigger
   });
+
+  if (!observersByDOMSelector.hasOwnProperty(settings.elementSelector)) {
+    observerQueue.push(settings.elementSelector);
+  }
 };

--- a/src/lib/helpers/intersectionObserverIntervals.json
+++ b/src/lib/helpers/intersectionObserverIntervals.json
@@ -1,0 +1,5 @@
+{
+  "standard": {
+    "pageElementsRefresh": 3000
+  }
+}

--- a/src/view/events/__tests__/change.test.jsx
+++ b/src/view/events/__tests__/change.test.jsx
@@ -216,7 +216,7 @@ describe('change event view', () => {
   it(
     'results in the showFieldCheckBox being checked when there is an empty ' +
       'string value from settings',
-    function () {
+    () => {
       extensionBridge.init({
         settings: {
           acceptableChangeValues: [{ value: '', valueIsRegex: true }],
@@ -237,7 +237,7 @@ describe('change event view', () => {
   it(
     'checking the showFieldCheckBox results in getting an empty string value ' +
       'in the settings',
-    function () {
+    () => {
       fireEvent.click(pageElements.valueField.getShowFieldCheckBox());
       const { acceptableChangeValues: valueRows } =
         extensionBridge.getSettings();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,10 +1504,42 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
+"@jridgewell/gen-mapping@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity "sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg= sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
   integrity sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==
+
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/sourcemap-codec@1.4.14":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity "sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ= sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.11"
@@ -1521,6 +1553,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
+  integrity "sha1-eTBBJ3r5BzsJUaf+Dw2MTJjDaYU= sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g=="
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@lezer/common@^0.15.0", "@lezer/common@^0.15.5":
   version "0.15.12"
@@ -4900,9 +4940,9 @@ debug@~3.1.0:
     ms "2.0.0"
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity "sha1-5p2+JdN5QRcd1UDgJMREzVGI4ek= sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
 
 decompress-response@^3.3.0:
   version "3.3.0"
@@ -6261,9 +6301,9 @@ globalthis@^1.0.1:
     define-properties "^1.1.3"
 
 got@^11.0.2, got@^11.7.0:
-  version "11.8.3"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
-  integrity sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==
+  version "11.8.6"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
+  integrity "sha1-J26Cfq2Hcu3bz8lxcFkLhBgjIzo= sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="
   dependencies:
     "@sindresorhus/is" "^4.0.0"
     "@szmarczak/http-timer" "^4.0.5"
@@ -6467,9 +6507,9 @@ http-cache-semantics@3.8.1:
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
 http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity "sha1-q+AvyymFRgvwMjvmZENuw0dqbVo= sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
 
 http-errors@1.8.1:
   version "1.8.1"
@@ -7102,9 +7142,9 @@ json5@^0.5.1:
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity "sha1-Y9mNYPIbMTt3xNbaGL+mnYDh1ZM= sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="
   dependencies:
     minimist "^1.2.0"
 
@@ -7307,9 +7347,9 @@ loader-runner@^4.2.0:
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
 loader-utils@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity "sha1-KalX86Y5c4g+toTxD/09FR/sAaM= sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg=="
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
@@ -7668,16 +7708,16 @@ moment-range@^3.0.3:
     es6-symbol "^3.1.0"
 
 moment-timezone@^0.5.33:
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
-  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  version "0.5.40"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.40.tgz#c148f5149fd91dd3e29bf481abc8830ecba16b89"
+  integrity "sha1-wUj1FJ/ZHdPim/SBq8iDDsuha4k= sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg=="
   dependencies:
     moment ">= 2.9.0"
 
 "moment@>= 2.9.0", moment@^2.15.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.0.0:
   version "2.0.0"
@@ -9185,9 +9225,9 @@ socket.io-adapter@~2.3.3:
   integrity sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==
 
 socket.io-parser@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
-  integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.5.tgz#cb404382c32324cc962f27f3a44058cf6e0552df"
+  integrity "sha1-y0BDgsMjJMyWLyfzpEBYz24FUt8= sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig=="
   dependencies:
     "@types/component-emitter" "^1.2.10"
     component-emitter "~1.3.0"
@@ -9271,7 +9311,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -9561,13 +9601,13 @@ terser-webpack-plugin@^5.1.3:
     terser "^5.7.2"
 
 terser@^5.10.0, terser@^5.7.2:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
-  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
+  version "5.16.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.3.tgz#3266017a9b682edfe019b8ecddd2abaae7b39c6b"
+  integrity "sha1-MmYBeptoLt/gGbjs3dKrqueznGs= sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q=="
   dependencies:
+    "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
     commander "^2.20.0"
-    source-map "~0.7.2"
     source-map-support "~0.5.20"
 
 text-table@^0.2.0:
@@ -9738,9 +9778,9 @@ type@^2.5.0:
   integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
 
 ua-parser-js@^0.7.21, ua-parser-js@^0.7.30:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
-  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.33.tgz#1d04acb4ccef9293df6f70f2c3d22f3030d8b532"
+  integrity "sha1-HQSstMzvkpPfb3Dyw9IvMDDYtTI= sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-6794

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

* Addresses #60 to remove polling timing code from the entersViewport logic.
* Bumps some dependencies.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] I have updated the Experience League documentation for the [Core Extension](https://git.corp.adobe.com/AdobeDocs/experience-platform.en/tree/master/help/tags/extensions/web/core)
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
