### PR TITLE
PDCL-11333: Fix schema for `elementProperties` of Form-Change event

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",

--- a/extension.json
+++ b/extension.json
@@ -153,28 +153,23 @@
         ],
         "$defs": {
           "specificElementsProperties": {
-            "type": "object",
-            "properties": {
-              "elementProperties": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "value": {
-                      "type": "string"
-                    },
-                    "valueIsRegex": {
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": ["name", "value"]
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "value": {
+                  "type": "string"
+                },
+                "valueIsRegex": {
+                  "type": "boolean"
                 }
-              }
+              },
+              "additionalProperties": false,
+              "required": ["name", "value"]
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-extension-core",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "This is the Core extension for Adobe Experience Platform Launch. It provides default event, condition, and data element types available to all Launch properties.",
   "author": {
     "name": "Adobe",

--- a/src/view/events/components/__tests__/specificElements.test.jsx
+++ b/src/view/events/components/__tests__/specificElements.test.jsx
@@ -60,6 +60,8 @@ describe('specificElements', () => {
 
     expect(pageElements.getPropertiesCheckbox().checked).toBeTrue();
     expect(screen.getByTestId('element-properties-editor')).toBeTruthy();
+
+    expect(extensionBridge.validate()).toBe(true);
   });
 
   it('updates view properly when elementProperties not provided', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes schema validation error for the `Form -> Change` event when `"and having certain property values..."` is active.
 - the schema was nested 1 level too deep

The bug...
- If working in a new rule with the latest Core version, the UI will fail to validate
- After upgrading the Core extension new builds will fail due to old settings in rule components

The error...
`"The property 'elementProperties' of type array did not match the following type: object"`

See PDCL-11333 for more details.



<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] I have updated the Experience League documentation for the [Core Extension](https://git.corp.adobe.com/AdobeDocs/experience-platform.en/tree/master/help/tags/extensions/web/core)
- [ ] All tests pass and I've made any necessary test changes.
- [ ] I have run the extension sandbox successfully.
