### PR TITLE
v3.4.4: add releaseNotesUrl

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
   "platform": "web",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "displayName": "Core",
   "description": "Provides default event, condition, and data element types available to all Launch properties.",
   "exchangeUrl": "https://www.adobeexchange.com/experiencecloud.details.100223.adobe-launch-core-extension.html",
@@ -11,6 +11,7 @@
     "url": "http://adobe.com",
     "email": "reactor@adobe.com"
   },
+  "releaseNotesUrl": "https://experienceleague.adobe.com/en/docs/experience-platform/tags/extensions/client/core/release-notes",
   "viewBasePath": "dist/",
   "configuration": {
     "viewPath": "configuration/configuration.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-extension-core",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "This is the Core extension for Adobe Experience Platform Launch. It provides default event, condition, and data element types available to all Launch properties.",
   "author": {
     "name": "Adobe",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a releaseNotesUrl to experience league for this extension to be consumed by the Lens UI.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-14172

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allows users to see what's changed in the Core extension before upgrading

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) (patch release change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have updated the Experience League documentation for the [Core Extension](https://git.corp.adobe.com/AdobeDocs/experience-platform.en/tree/master/help/tags/extensions/web/core)
- [x] All tests pass and I've made any necessary test changes.
- [ ] I have run the extension sandbox successfully.
